### PR TITLE
feat: Implement login screen

### DIFF
--- a/app/src/main/java/com/example/store/presentation/common/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/example/store/presentation/common/navigation/MainNavHost.kt
@@ -1,13 +1,13 @@
 package com.example.store.presentation.common.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.example.store.presentation.dashboard.ui.DashboardScreen
+import com.example.store.presentation.login.ui.LoginScreen
 import com.example.store.presentation.splash.ui.SplashScreen
-
-
 
 @Composable
 fun MainNavHost(navController: NavHostController) {
@@ -18,9 +18,20 @@ fun MainNavHost(navController: NavHostController) {
         composable("splash") {
             SplashScreen(
                 onTimeout = {
-                    navController.navigate("dashboard") {
+                    navController.navigate("login") {
                         launchSingleTop = true
                         popUpTo("splash") { inclusive = true }
+                    }
+                }
+            )
+        }
+        composable("login") {
+            LoginScreen(
+                // viewModel is provided by default from hiltViewModel or viewModel()
+                onLoginSuccess = {
+                    navController.navigate("dashboard") {
+                        launchSingleTop = true
+                        popUpTo("login") { inclusive = true } // Pop login from back stack
                     }
                 }
             )

--- a/app/src/main/java/com/example/store/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/store/presentation/login/LoginViewModel.kt
@@ -1,0 +1,54 @@
+package com.example.store.presentation.login
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class LoginUiState(
+    val username: String = "",
+    val password: String = "",
+    val isLoading: Boolean = false,
+    val loginError: String? = null,
+    val loginSuccess: Boolean = false
+)
+
+class LoginViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(LoginUiState())
+    val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
+
+    fun onUsernameChange(username: String) {
+        _uiState.update { it.copy(username = username, loginError = null) }
+    }
+
+    fun onPasswordChange(password: String) {
+        _uiState.update { it.copy(password = password, loginError = null) }
+    }
+
+    fun onLoginClicked() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, loginError = null) }
+            // Simulate network call
+            kotlinx.coroutines.delay(1000)
+
+            if (_uiState.value.username == "user" && _uiState.value.password == "password") {
+                _uiState.update { it.copy(isLoading = false, loginSuccess = true) }
+            } else {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        loginError = "Invalid username or password."
+                    )
+                }
+            }
+        }
+    }
+
+    fun onLoginHandled() {
+        _uiState.update { it.copy(loginSuccess = false, loginError = null) }
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/login/ui/LoginScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/login/ui/LoginScreen.kt
@@ -1,0 +1,89 @@
+package com.example.store.presentation.login.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.store.presentation.login.LoginViewModel
+
+@Composable
+fun LoginScreen(
+    viewModel: LoginViewModel = viewModel(),
+    onLoginSuccess: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(uiState.loginSuccess) {
+        if (uiState.loginSuccess) {
+            onLoginSuccess()
+            viewModel.onLoginHandled() // Reset login success state
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Login",
+            style = MaterialTheme.typography.headlineMedium,
+            modifier = Modifier.padding(bottom = 24.dp)
+        )
+
+        OutlinedTextField(
+            value = uiState.username,
+            onValueChange = { viewModel.onUsernameChange(it) },
+            label = { Text("Username") },
+            modifier = Modifier.fillMaxWidth(),
+            isError = uiState.loginError != null,
+            singleLine = true
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = uiState.password,
+            onValueChange = { viewModel.onPasswordChange(it) },
+            label = { Text("Password") },
+            modifier = Modifier.fillMaxWidth(),
+            visualTransformation = PasswordVisualTransformation(),
+            isError = uiState.loginError != null,
+            singleLine = true
+        )
+
+        uiState.loginError?.let {
+            Text(
+                text = it,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(
+            onClick = { viewModel.onLoginClicked() },
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !uiState.isLoading
+        ) {
+            if (uiState.isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+            } else {
+                Text("Login")
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/example/store/presentation/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/example/store/presentation/login/LoginViewModelTest.kt
@@ -1,0 +1,110 @@
+package com.example.store.presentation.login
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class LoginViewModelTest {
+
+    private lateinit var viewModel: LoginViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = LoginViewModel()
+    }
+
+    @Test
+    fun `onUsernameChange updates username in uiState`() = runTest {
+        val newUsername = "testUser"
+        viewModel.onUsernameChange(newUsername)
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.username).isEqualTo(newUsername)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onPasswordChange updates password in uiState`() = runTest {
+        val newPassword = "testPassword"
+        viewModel.onPasswordChange(newPassword)
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.password).isEqualTo(newPassword)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onLoginClicked with correct credentials updates uiState to loginSuccess`() = runTest {
+        viewModel.onUsernameChange("user")
+        viewModel.onPasswordChange("password")
+
+        viewModel.uiState.test {
+            skipItems(2) // Skip initial state and username/password updates
+
+            viewModel.onLoginClicked()
+
+            var emission = awaitItem()
+            assertThat(emission.isLoading).isTrue() // Start loading
+
+            emission = awaitItem() // Loading finished
+            assertThat(emission.isLoading).isFalse()
+            assertThat(emission.loginSuccess).isTrue()
+            assertThat(emission.loginError).isNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onLoginClicked with incorrect credentials updates uiState with error`() = runTest {
+        viewModel.onUsernameChange("wrongUser")
+        viewModel.onPasswordChange("wrongPassword")
+
+        viewModel.uiState.test {
+            skipItems(2) // Skip initial state and username/password updates
+
+            viewModel.onLoginClicked()
+
+            var emission = awaitItem()
+            assertThat(emission.isLoading).isTrue() // Start loading
+
+            emission = awaitItem() // Loading finished
+            assertThat(emission.isLoading).isFalse()
+            assertThat(emission.loginSuccess).isFalse()
+            assertThat(emission.loginError).isNotNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onLoginHandled resets loginSuccess and loginError`() = runTest {
+        // Simulate a successful login
+        viewModel.onUsernameChange("user")
+        viewModel.onPasswordChange("password")
+        viewModel.onLoginClicked()
+        advanceUntilIdle() // Ensure login click processing is complete
+
+        viewModel.onLoginHandled()
+
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.loginSuccess).isFalse()
+            assertThat(emission.loginError).isNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
- Added LoginScreen.kt with Jetpack Compose UI for username/password input and a login button.
- Implemented LoginViewModel.kt to manage login state, handle input validation (mocked), and user authentication.
- Integrated the login screen into the main navigation flow (MainNavHost.kt). The app now navigates from Splash to Login, and then to Dashboard upon successful login.
- Added unit tests for LoginViewModel to verify its logic.