### PR TITLE
feat: Implement basic Inventory screen

### DIFF
--- a/app/src/androidTest/java/com/example/store/presentation/inventory/InventoryScreenTest.kt
+++ b/app/src/androidTest/java/com/example/store/presentation/inventory/InventoryScreenTest.kt
@@ -1,0 +1,138 @@
+package com.example.store.presentation.inventory
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.compose.rememberNavController
+import com.example.store.presentation.inventory.model.InventoryItemUi
+import com.example.store.presentation.inventory.ui.InventoryScreen
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+// Using createComposeRule() for more direct Composable testing without full Activity context
+// For tests involving NavController that's part of a larger graph, createAndroidComposeRule might be needed.
+class InventoryScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // Mock ViewModel
+    private lateinit var mockViewModel: InventoryViewModel
+    private val mockUiState = MutableStateFlow(InventoryUiState())
+
+    private val sampleItems = listOf(
+        InventoryItemUi(id = "1", name = "Test Apple", quantity = 10, price = 1.0),
+        InventoryItemUi(id = "2", name = "Test Banana", quantity = 5, price = 0.5)
+    )
+
+    @Before
+    fun setUp() {
+        // Mock the ViewModel and its StateFlow
+        mockViewModel = mock<InventoryViewModel> {
+            on { uiState } doReturn mockUiState
+        }
+        // Set initial state for most tests
+        mockUiState.value = InventoryUiState(items = sampleItems, isLoading = false)
+
+        composeTestRule.setContent {
+            // It's good practice to wrap in a MaterialTheme if your composables use it,
+            // but for simple tests focusing on InventoryScreen, it might not be strictly necessary
+            // if it doesn't rely on theme attributes directly for basic layout/text.
+            // For robustness: MaterialTheme { InventoryScreen(viewModel = mockViewModel) }
+            InventoryScreen(viewModel = mockViewModel)
+        }
+    }
+
+    @Test
+    fun inventoryScreen_displaysItemsFromViewModel() {
+        composeTestRule.onNodeWithText("Test Apple").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Qty: 10").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Price: $1.00").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("Test Banana").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Qty: 5").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Price: $0.50").assertIsDisplayed()
+    }
+
+    @Test
+    fun inventoryScreen_showsLoadingIndicatorWhenLoading() {
+        mockUiState.value = InventoryUiState(isLoading = true)
+        composeTestRule.onNode(isRoot()).printToLog("LoadingState") // For debugging
+        // Check for a CircularProgressIndicator. A common way is to check for its test tag if you've set one.
+        // Or, if it's the only prominent element, you might check other elements are not displayed.
+        // For simplicity, we'll assume it's the only thing and other text isn't there.
+        // This is a weak assertion, better to use testTag on CircularProgressIndicator.
+        composeTestRule.onNodeWithText("Test Apple").assertDoesNotExist() // Assuming items are not shown when loading
+        // Add specific check for progress indicator if possible, e.g., by testTag
+    }
+
+    @Test
+    fun inventoryScreen_showsNoItemsMessageWhenListIsEmptyAndNotLoading() {
+        mockUiState.value = InventoryUiState(items = emptyList(), isLoading = false)
+        composeTestRule.onNodeWithText("No items in inventory.").assertIsDisplayed()
+    }
+
+    @Test
+    fun fabClick_showsToastPlaceholder() {
+        // The actual Toast is tricky to test with composeTestRule directly as it's outside the composition.
+        // We will verify the ViewModel interaction that *would* lead to a Toast.
+        // In the actual InventoryScreen, FAB click shows a Toast directly for now.
+        // So, this test is more about the FAB being clickable.
+        // To test the Toast text itself, you'd need Espresso with onToast.
+        // For now, let's just ensure the FAB is there.
+        composeTestRule.onNodeWithContentDescription("Add Item").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Add Item").performClick()
+        // Verification of Toast message would ideally be done via Espresso or a test rule that captures Toasts.
+        // Since the FAB in the current implementation directly shows a toast,
+        // we can't easily verify the text with Compose UI testing alone.
+        // If the FAB called a ViewModel method, we could verify that:
+        // Mockito.verify(mockViewModel).someMethodRelatedToFab()
+    }
+
+    @Test
+    fun deleteButtonClick_callsViewModelDelete() {
+        val itemToDelete = sampleItems.first()
+        composeTestRule.onNodeWithContentDescription("Delete ${itemToDelete.name}").performClick()
+        Mockito.verify(mockViewModel).deleteItem(itemToDelete.id)
+    }
+
+    @Test
+    fun editButtonClick_callsViewModelEditPlaceholder() {
+        val itemToEdit = sampleItems.first()
+        composeTestRule.onNodeWithContentDescription("Edit ${itemToEdit.name}").performClick()
+        Mockito.verify(mockViewModel).editItemPlaceholder(itemToEdit.id)
+    }
+
+    @Test
+    fun userMessageInUiState_triggersLaunchedEffectAndCallsOnUserMessageShown() {
+        // Set a user message
+        mockUiState.value = InventoryUiState(items = sampleItems, userMessage = "Test Message")
+
+        // Recompose if necessary, though collectAsState should handle it.
+        // composeTestRule.waitForIdle() // Ensure LaunchedEffect has a chance to run
+
+        // Verify that onUserMessageShown was called (due to LaunchedEffect)
+        // This needs careful handling of how LaunchedEffect and StateFlow emissions are tested.
+        // The LaunchedEffect will trigger the Toast and then call onUserMessageShown.
+        // We need to ensure the recomposition happens and the effect runs.
+
+        // Due to the nature of LaunchedEffect and state consumption,
+        // directly verifying onUserMessageShown after setting the state can be tricky
+        // without more advanced test schedulers or waiting mechanisms for effects.
+        // The LaunchedEffect should consume the message.
+        // A simple way to check if the consumption logic is wired:
+        // After the message is set, if the ViewModel's onUserMessageShown is called,
+        // the message should eventually be nullified in a subsequent state if the VM updates it.
+
+        // For this test, we'll verify the call. It assumes the LaunchedEffect runs.
+        // This might require advancing clocks or specific dispatcher configurations in more complex scenarios.
+        composeTestRule.runOnIdle { // Ensure composition and effects have settled
+             Mockito.verify(mockViewModel).onUserMessageShown()
+        }
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/inventory/InventoryViewModel.kt
+++ b/app/src/main/java/com/example/store/presentation/inventory/InventoryViewModel.kt
@@ -1,0 +1,85 @@
+package com.example.store.presentation.inventory
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.store.presentation.inventory.model.InventoryItemUi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class InventoryUiState(
+    val items: List<InventoryItemUi> = emptyList(),
+    val isLoading: Boolean = false,
+    val userMessage: String? = null // For Toasts or Snackbars
+)
+
+class InventoryViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(InventoryUiState())
+    val uiState: StateFlow<InventoryUiState> = _uiState.asStateFlow()
+
+    init {
+        loadInventoryItems()
+    }
+
+    private fun loadInventoryItems() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            // Simulate network/db delay
+            kotlinx.coroutines.delay(1000)
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    items = createMockInventoryItems()
+                )
+            }
+        }
+    }
+
+    fun addItem(name: String, quantity: Int, price: Double) {
+        // In a real app, this would involve a repository call
+        val newItem = InventoryItemUi(name = name, quantity = quantity, price = price)
+        _uiState.update {
+            it.copy(
+                items = it.items + newItem,
+                userMessage = "Item '${newItem.name}' added."
+            )
+        }
+    }
+
+    fun deleteItem(itemId: String) {
+        val itemToDelete = _uiState.value.items.find { it.id == itemId }
+        _uiState.update {
+            it.copy(
+                items = it.items.filterNot { item -> item.id == itemId },
+                userMessage = itemToDelete?.let { "Item '${it.name}' deleted." } ?: "Item not found."
+            )
+        }
+    }
+
+    fun editItemPlaceholder(itemId: String) {
+        // This is a placeholder for future edit functionality
+        val itemToEdit = _uiState.value.items.find { it.id == itemId }
+        _uiState.update {
+            it.copy(userMessage = itemToEdit?.let { "Edit action for '${it.name}' triggered." } ?: "Item not found for edit.")
+        }
+    }
+
+    fun onUserMessageShown() {
+        _uiState.update { it.copy(userMessage = null) }
+    }
+
+    private fun createMockInventoryItems(): List<InventoryItemUi> {
+        return listOf(
+            InventoryItemUi(name = "Apples", quantity = 50, price = 0.5, category = "Fruits"),
+            InventoryItemUi(name = "Bananas", quantity = 100, price = 0.3, category = "Fruits"),
+            InventoryItemUi(name = "Milk (1L)", quantity = 20, price = 1.2, category = "Dairy"),
+            InventoryItemUi(name = "Bread Loaf", quantity = 30, price = 2.0, category = "Bakery"),
+            InventoryItemUi(name = "Chicken Breast (kg)", quantity = 15, price = 8.0, category = "Meat"),
+            InventoryItemUi(name = "Cereal Box", quantity = 25, price = 3.5, category = "Pantry"),
+            InventoryItemUi(name = "Eggs (dozen)", quantity = 40, price = 2.5, category = "Dairy")
+        )
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/inventory/model/InventoryItemUi.kt
+++ b/app/src/main/java/com/example/store/presentation/inventory/model/InventoryItemUi.kt
@@ -1,0 +1,16 @@
+package com.example.store.presentation.inventory.model
+
+import java.util.UUID
+
+data class InventoryItemUi(
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val quantity: Int,
+    val price: Double,
+    val category: String? = null // Optional: for future use
+) {
+    // Helper to format price, can be expanded
+    fun getFormattedPrice(): String {
+        return String.format("$%.2f", price)
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/inventory/ui/InventoryScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/inventory/ui/InventoryScreen.kt
@@ -1,20 +1,124 @@
-package com.example.store.presentation.inventory.ui // Changed package name
+package com.example.store.presentation.inventory.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import android.widget.Toast
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.store.presentation.inventory.InventoryViewModel
+import com.example.store.presentation.inventory.model.InventoryItemUi
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InventoryScreen(
+    viewModel: InventoryViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(key1 = uiState.userMessage) {
+        uiState.userMessage?.let {
+            Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+            viewModel.onUserMessageShown() // Important to consume the message
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Inventory Management") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = {
+                // For now, just a toast. Later, this can open a dialog/screen.
+                // Example of how to call add item - parameters would come from a dialog
+                // viewModel.addItem("New Item from FAB", 10, 1.99)
+                Toast.makeText(context, "Add new item clicked (placeholder)", Toast.LENGTH_SHORT).show()
+            }) {
+                Icon(Icons.Filled.Add, contentDescription = "Add Item")
+            }
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            if (uiState.isLoading) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            } else if (uiState.items.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("No items in inventory.", style = MaterialTheme.typography.bodyLarge)
+                }
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    items(uiState.items, key = { it.id }) { item ->
+                        InventoryListItem(
+                            item = item,
+                            onEditClick = { viewModel.editItemPlaceholder(item.id) },
+                            onDeleteClick = { viewModel.deleteItem(item.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
 
 @Composable
-fun InventoryScreen() { // Changed function name
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+fun InventoryListItem(
+    item: InventoryItemUi,
+    onEditClick: () -> Unit,
+    onDeleteClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
-        Text(text = "Inventory Screen") // Changed text
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(item.name, style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold))
+                Spacer(modifier = Modifier.height(4.dp))
+                Text("Qty: ${item.quantity}", style = MaterialTheme.typography.bodyMedium)
+                Text("Price: ${item.getFormattedPrice()}", style = MaterialTheme.typography.bodyMedium)
+                item.category?.let {
+                    Text("Category: $it", style = MaterialTheme.typography.bodySmall)
+                }
+            }
+            Row {
+                IconButton(onClick = onEditClick) {
+                    Icon(Icons.Filled.Edit, contentDescription = "Edit ${item.name}")
+                }
+                IconButton(onClick = onDeleteClick) {
+                    Icon(Icons.Filled.Delete, contentDescription = "Delete ${item.name}", tint = MaterialTheme.colorScheme.error)
+                }
+            }
+        }
     }
 }

--- a/app/src/test/java/com/example/store/presentation/inventory/InventoryViewModelTest.kt
+++ b/app/src/test/java/com/example/store/presentation/inventory/InventoryViewModelTest.kt
@@ -1,0 +1,142 @@
+package com.example.store.presentation.inventory
+
+import app.cash.turbine.test
+import com.example.store.presentation.inventory.model.InventoryItemUi
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class InventoryViewModelTest {
+
+    private lateinit var viewModel: InventoryViewModel
+    private val testDispatcher = StandardTestDispatcher() // For more control if needed, UnconfinedTestDispatcher also works for many cases
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = InventoryViewModel()
+        // Advance past the init block's loadInventoryItems coroutine
+        // For StandardTestDispatcher, you need to advance time or runCurrent.
+        // If using UnconfinedTestDispatcher, it might run eagerly.
+        // runCurrent() will execute tasks scheduled at the current virtual time.
+        testDispatcher.scheduler.runCurrent()
+    }
+
+    @Test
+    fun `initial state loads mock items`() = runTest {
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.isLoading).isFalse() // Should be false after init load
+            assertThat(emission.items).isNotEmpty()
+            assertThat(emission.items.any { it.name == "Apples" }).isTrue()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `addItem adds new item and sets userMessage`() = runTest {
+        val initialItemCount = viewModel.uiState.value.items.size
+        val itemName = "Test Item"
+        val itemQuantity = 10
+        val itemPrice = 5.99
+
+        viewModel.addItem(itemName, itemQuantity, itemPrice)
+
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.items.size).isEqualTo(initialItemCount + 1)
+            val addedItem = emission.items.find { it.name == itemName }
+            assertThat(addedItem).isNotNull()
+            assertThat(addedItem?.quantity).isEqualTo(itemQuantity)
+            assertThat(addedItem?.price).isEqualTo(itemPrice)
+            assertThat(emission.userMessage).isEqualTo("Item '$itemName' added.")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `deleteItem removes item and sets userMessage`() = runTest {
+        // Get an item to delete (e.g., the first mock item)
+        val itemToDelete = viewModel.uiState.value.items.firstOrNull()
+        assertThat(itemToDelete).isNotNull()
+        itemToDelete?.let {
+            val initialItemCount = viewModel.uiState.value.items.size
+            viewModel.deleteItem(it.id)
+
+            viewModel.uiState.test {
+                val emission = awaitItem()
+                assertThat(emission.items.size).isEqualTo(initialItemCount - 1)
+                assertThat(emission.items.find { item -> item.id == it.id }).isNull()
+                assertThat(emission.userMessage).isEqualTo("Item '${it.name}' deleted.")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `deleteItem with non-existent id sets appropriate userMessage`() = runTest {
+        val nonExistentId = "non-existent-id"
+        val initialItemCount = viewModel.uiState.value.items.size
+        viewModel.deleteItem(nonExistentId)
+
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.items.size).isEqualTo(initialItemCount) // No change in item count
+            assertThat(emission.userMessage).isEqualTo("Item not found.")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+
+    @Test
+    fun `editItemPlaceholder sets userMessage`() = runTest {
+        val itemToEdit = viewModel.uiState.value.items.firstOrNull()
+        assertThat(itemToEdit).isNotNull()
+        itemToEdit?.let {
+            viewModel.editItemPlaceholder(it.id)
+            viewModel.uiState.test {
+                val emission = awaitItem()
+                assertThat(emission.userMessage).isEqualTo("Edit action for '${it.name}' triggered.")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `editItemPlaceholder with non-existent id sets appropriate userMessage`() = runTest {
+        val nonExistentId = "non-existent-id"
+        viewModel.editItemPlaceholder(nonExistentId)
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isEqualTo("Item not found for edit.")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onUserMessageShown clears userMessage`() = runTest {
+        // First, set a message
+        viewModel.addItem("Temp Item", 1, 1.0)
+        // Advance past the addItem coroutine if it's not immediate
+        testDispatcher.scheduler.runCurrent()
+
+        assertThat(viewModel.uiState.value.userMessage).isNotNull()
+
+        viewModel.onUserMessageShown()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
- Added InventoryItemUi data class.
- Implemented InventoryViewModel with mock data, state management, and functions for add, delete, and edit (placeholder) operations.
- Designed and implemented InventoryScreen UI using Jetpack Compose, displaying a list of items, a FAB, and edit/delete actions per item.
- Included Toast messages for user feedback on actions.
- Added unit tests for InventoryViewModel.
- Added basic UI tests for InventoryScreen.