### PR TITLE
feat: Implement basic Purchases screen

### DIFF
--- a/app/src/androidTest/java/com/example/store/presentation/purchases/PurchasesScreenTest.kt
+++ b/app/src/androidTest/java/com/example/store/presentation/purchases/PurchasesScreenTest.kt
@@ -1,0 +1,91 @@
+package com.example.store.presentation.purchases
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.example.store.presentation.purchases.model.PurchaseItemUi
+import com.example.store.presentation.purchases.ui.PurchasesScreen
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+
+class PurchasesScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var mockViewModel: PurchasesViewModel
+    private val mockUiState = MutableStateFlow(PurchasesUiState())
+
+    private val samplePurchases = listOf(
+        PurchaseItemUi(id = "1", productName = "Test Apples", supplierName = "Farm Fresh", quantity = 5, unitPrice = 2.0),
+        PurchaseItemUi(id = "2", productName = "Test Milk", supplierName = "Dairy Co", quantity = 2, unitPrice = 1.5)
+    )
+
+    @Before
+    fun setUp() {
+        mockViewModel = mock<PurchasesViewModel> {
+            on { uiState } doReturn mockUiState
+        }
+        // Set initial state for most tests
+        mockUiState.value = PurchasesUiState(purchases = samplePurchases, isLoading = false)
+
+        composeTestRule.setContent {
+            PurchasesScreen(viewModel = mockViewModel)
+        }
+    }
+
+    @Test
+    fun purchasesScreen_displaysItemsFromViewModel() {
+        composeTestRule.onNodeWithText("Test Apples").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Qty: 5 @ ${samplePurchases[0].getFormattedUnitPrice()} each").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Supplier: Farm Fresh").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Total: ${samplePurchases[0].getFormattedTotalPrice()}").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("Test Milk").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Qty: 2 @ ${samplePurchases[1].getFormattedUnitPrice()} each").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Supplier: Dairy Co").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Total: ${samplePurchases[1].getFormattedTotalPrice()}").assertIsDisplayed()
+    }
+
+    @Test
+    fun purchasesScreen_showsLoadingIndicatorWhenLoading() {
+        mockUiState.value = PurchasesUiState(isLoading = true)
+        // Assuming CircularProgressIndicator is shown and items are not
+        composeTestRule.onNodeWithText("Test Apples").assertDoesNotExist()
+        // Add a more specific check for the loading indicator if it has a testTag
+    }
+
+    @Test
+    fun purchasesScreen_showsNoPurchasesMessageWhenListIsEmptyAndNotLoading() {
+        mockUiState.value = PurchasesUiState(purchases = emptyList(), isLoading = false)
+        composeTestRule.onNodeWithText("No purchase history found.").assertIsDisplayed()
+    }
+
+    @Test
+    fun fabClick_callsViewModelRecordNewPurchasePlaceholder() {
+        composeTestRule.onNodeWithContentDescription("Record New Purchase").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Record New Purchase").performClick()
+        verify(mockViewModel).recordNewPurchasePlaceholder()
+    }
+
+    @Test
+    fun purchaseItemClick_callsViewModelViewPurchaseDetailsPlaceholder() {
+        val firstPurchase = samplePurchases.first()
+        // Click on the Card containing the first purchase's product name
+        composeTestRule.onNodeWithText(firstPurchase.productName).performClick()
+        verify(mockViewModel).viewPurchaseDetailsPlaceholder(firstPurchase.id)
+    }
+
+    @Test
+    fun userMessageInUiState_triggersLaunchedEffectAndCallsOnUserMessageShown() {
+        mockUiState.value = PurchasesUiState(purchases = samplePurchases, userMessage = "Test Purchase Message")
+
+        composeTestRule.runOnIdle { // Ensure composition and effects have settled
+             verify(mockViewModel).onUserMessageShown()
+        }
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/purchases/PurchasesViewModel.kt
+++ b/app/src/main/java/com/example/store/presentation/purchases/PurchasesViewModel.kt
@@ -1,0 +1,96 @@
+package com.example.store.presentation.purchases
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.store.presentation.purchases.model.PurchaseItemUi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class PurchasesUiState(
+    val purchases: List<PurchaseItemUi> = emptyList(),
+    val isLoading: Boolean = false,
+    val userMessage: String? = null
+)
+
+class PurchasesViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PurchasesUiState())
+    val uiState: StateFlow<PurchasesUiState> = _uiState.asStateFlow()
+
+    init {
+        loadPurchaseHistory()
+    }
+
+    private fun loadPurchaseHistory() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            kotlinx.coroutines.delay(1000) // Simulate data loading
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    purchases = createMockPurchases()
+                )
+            }
+        }
+    }
+
+    fun recordNewPurchasePlaceholder() {
+        // In a real app, this would likely navigate to a new screen or show a detailed dialog
+        // For now, just a message.
+        _uiState.update {
+            it.copy(userMessage = "Record New Purchase action triggered (Placeholder).")
+        }
+    }
+
+    fun viewPurchaseDetailsPlaceholder(purchaseId: String) {
+        val purchase = _uiState.value.purchases.find { it.id == purchaseId }
+        _uiState.update {
+            it.copy(
+                userMessage = purchase?.let { p ->
+                    "Viewing details for purchase of '${p.productName}' (Placeholder)."
+                } ?: "Purchase not found."
+            )
+        }
+    }
+
+    fun onUserMessageShown() {
+        _uiState.update { it.copy(userMessage = null) }
+    }
+
+    private fun createMockPurchases(): List<PurchaseItemUi> {
+        val currentTime = System.currentTimeMillis()
+        return listOf(
+            PurchaseItemUi(
+                productName = "Apples (Box)",
+                supplierName = "Fresh Farms Inc.",
+                quantity = 5,
+                unitPrice = 10.0, // Price per box
+                purchaseDate = currentTime - (2 * 24 * 60 * 60 * 1000) // 2 days ago
+            ),
+            PurchaseItemUi(
+                productName = "Milk Cartons (Case)",
+                supplierName = "Dairy Best",
+                quantity = 10,
+                unitPrice = 12.5, // Price per case
+                purchaseDate = currentTime - (1 * 24 * 60 * 60 * 1000) // 1 day ago
+            ),
+            PurchaseItemUi(
+                productName = "Printer Paper (Ream)",
+                supplierName = "Office Supplies Co.",
+                quantity = 20,
+                unitPrice = 4.0, // Price per ream
+                purchaseDate = currentTime
+            ),
+            PurchaseItemUi(
+                productName = "Cleaning Solution (Bottle)",
+                supplierName = "CleanPro Ltd.",
+                quantity = 10,
+                unitPrice = 3.5,
+                purchaseDate = currentTime - (5 * 24 * 60 * 60 * 1000) // 5 days ago
+            )
+        ).sortedByDescending { it.purchaseDate }
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/purchases/model/PurchaseItemUi.kt
+++ b/app/src/main/java/com/example/store/presentation/purchases/model/PurchaseItemUi.kt
@@ -1,0 +1,31 @@
+package com.example.store.presentation.purchases.model
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+
+data class PurchaseItemUi(
+    val id: String = UUID.randomUUID().toString(),
+    val productName: String,
+    val supplierName: String?, // Optional: A purchase might not always have a supplier if it's a misc expense recorded here
+    val quantity: Int,
+    val unitPrice: Double,
+    val purchaseDate: Long = System.currentTimeMillis() // Store as timestamp
+) {
+    val totalPrice: Double
+        get() = quantity * unitPrice
+
+    fun getFormattedDate(): String {
+        val sdf = SimpleDateFormat("dd MMM yyyy, HH:mm", Locale.getDefault())
+        return sdf.format(Date(purchaseDate))
+    }
+
+    fun getFormattedTotalPrice(): String {
+        return String.format("$%.2f", totalPrice)
+    }
+
+    fun getFormattedUnitPrice(): String {
+        return String.format("$%.2f", unitPrice)
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/purchases/ui/PurchasesScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/purchases/ui/PurchasesScreen.kt
@@ -1,20 +1,125 @@
 package com.example.store.presentation.purchases.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.store.presentation.purchases.PurchasesViewModel
+import com.example.store.presentation.purchases.model.PurchaseItemUi
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PurchasesScreen(
+    viewModel: PurchasesViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(key1 = uiState.userMessage) {
+        uiState.userMessage?.let {
+            Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+            viewModel.onUserMessageShown()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Purchase History") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = {
+                viewModel.recordNewPurchasePlaceholder()
+            }) {
+                Icon(Icons.Filled.Add, contentDescription = "Record New Purchase")
+            }
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            if (uiState.isLoading) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            } else if (uiState.purchases.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("No purchase history found.", style = MaterialTheme.typography.bodyLarge)
+                }
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    items(uiState.purchases, key = { it.id }) { purchase ->
+                        PurchaseListItem(
+                            purchase = purchase,
+                            onClick = { viewModel.viewPurchaseDetailsPlaceholder(purchase.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
 
 @Composable
-fun PurchasesScreen() {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+fun PurchaseListItem(
+    purchase: PurchaseItemUi,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
-        Text(text = "Purchases Screen")
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth()
+        ) {
+            Text(
+                purchase.productName,
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text("Qty: ${purchase.quantity} @ ${purchase.getFormattedUnitPrice()} each", style = MaterialTheme.typography.bodyMedium)
+            purchase.supplierName?.let {
+                Text("Supplier: $it", style = MaterialTheme.typography.bodySmall)
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "Total: ${purchase.getFormattedTotalPrice()}",
+                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
+                )
+                Text(
+                    purchase.getFormattedDate(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
     }
 }

--- a/app/src/test/java/com/example/store/presentation/purchases/PurchasesViewModelTest.kt
+++ b/app/src/test/java/com/example/store/presentation/purchases/PurchasesViewModelTest.kt
@@ -1,0 +1,99 @@
+package com.example.store.presentation.purchases
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class PurchasesViewModelTest {
+
+    private lateinit var viewModel: PurchasesViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = PurchasesViewModel()
+        // Advance past the init block's loadPurchaseHistory coroutine
+        testDispatcher.scheduler.runCurrent()
+    }
+
+    @Test
+    fun `initial state loads mock purchases`() = runTest {
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.isLoading).isFalse() // Should be false after init load
+            assertThat(emission.purchases).isNotEmpty()
+            // Check for a known item from mock data
+            assertThat(emission.purchases.any { it.productName == "Apples (Box)" }).isTrue()
+            // Check if sorted by date descending (most recent first)
+            if (emission.purchases.size > 1) {
+                assertThat(emission.purchases[0].purchaseDate)
+                    .isAtLeast(emission.purchases[1].purchaseDate)
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `recordNewPurchasePlaceholder sets userMessage`() = runTest {
+        viewModel.recordNewPurchasePlaceholder()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isEqualTo("Record New Purchase action triggered (Placeholder).")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `viewPurchaseDetailsPlaceholder sets userMessage for existing item`() = runTest {
+        val firstPurchase = viewModel.uiState.value.purchases.firstOrNull()
+        assertThat(firstPurchase).isNotNull()
+
+        firstPurchase?.let {
+            viewModel.viewPurchaseDetailsPlaceholder(it.id)
+            viewModel.uiState.test {
+                val emission = awaitItem()
+                assertThat(emission.userMessage).isEqualTo("Viewing details for purchase of '${it.productName}' (Placeholder).")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `viewPurchaseDetailsPlaceholder sets userMessage for non-existent item`() = runTest {
+        val nonExistentId = "non-existent-id-123"
+        viewModel.viewPurchaseDetailsPlaceholder(nonExistentId)
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isEqualTo("Purchase not found.")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onUserMessageShown clears userMessage`() = runTest {
+        // Set a message first
+        viewModel.recordNewPurchasePlaceholder()
+        testDispatcher.scheduler.runCurrent() // Ensure state update is processed
+
+        assertThat(viewModel.uiState.value.userMessage).isNotNull()
+
+        viewModel.onUserMessageShown()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
- Added PurchaseItemUi data class for representing purchase items.
- Implemented PurchasesViewModel with mock data, UiState, and placeholder functions for recording new purchases and viewing details.
- Designed and implemented PurchasesScreen UI using Jetpack Compose, displaying a list of purchases, a FAB, and click handlers for items.
- Integrated Toast messages for user feedback on actions via ViewModel state.
- Added unit tests for PurchasesViewModel.
- Added basic UI tests for PurchasesScreen.