### PR TITLE
feat: Implement basic Sales screen

### DIFF
--- a/app/src/androidTest/java/com/example/store/presentation/sales/SalesScreenTest.kt
+++ b/app/src/androidTest/java/com/example/store/presentation/sales/SalesScreenTest.kt
@@ -1,0 +1,106 @@
+package com.example.store.presentation.sales
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.example.store.presentation.sales.model.SaleItemUi
+import com.example.store.presentation.sales.model.SoldItemSimple
+import com.example.store.presentation.sales.ui.SalesScreen
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+
+class SalesScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var mockViewModel: SalesViewModel
+    private val mockUiState = MutableStateFlow(SalesUiState())
+
+    private val sampleSales = listOf(
+        SaleItemUi(
+            id = "1",
+            transactionId = "SALE-001",
+            itemsSoldSummary = "Apples (1), Bananas (2)",
+            items = listOf(SoldItemSimple("Apples", 1, 0.5), SoldItemSimple("Bananas", 2, 0.3)),
+            totalAmount = 1.1,
+            customerName = "Customer A"
+        ),
+        SaleItemUi(
+            id = "2",
+            transactionId = "SALE-002",
+            itemsSoldSummary = "Milk (1)",
+            items = listOf(SoldItemSimple("Milk", 1, 1.2)),
+            totalAmount = 1.2
+        )
+    )
+
+    @Before
+    fun setUp() {
+        mockViewModel = mock<SalesViewModel> {
+            on { uiState } doReturn mockUiState
+        }
+        mockUiState.value = SalesUiState(sales = sampleSales, isLoading = false)
+
+        composeTestRule.setContent {
+            SalesScreen(viewModel = mockViewModel)
+        }
+    }
+
+    @Test
+    fun salesScreen_displaysItemsFromViewModel() {
+        // Test first sale item
+        composeTestRule.onNodeWithText("ID: SALE-001").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Items: Apples (1), Bananas (2)").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Customer: Customer A").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Total: ${sampleSales[0].getFormattedTotalAmount()}").assertIsDisplayed()
+
+        // Test second sale item
+        composeTestRule.onNodeWithText("ID: SALE-002").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Items: Milk (1)").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Total: ${sampleSales[1].getFormattedTotalAmount()}").assertIsDisplayed()
+        // Check that "Customer:" is not displayed if customerName is null
+        composeTestRule.onNodeWithText("Customer: ", substring = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun salesScreen_showsLoadingIndicatorWhenLoading() {
+        mockUiState.value = SalesUiState(isLoading = true)
+        composeTestRule.onNodeWithText("ID: SALE-001").assertDoesNotExist()
+        // Add a more specific check for the loading indicator if it has a testTag
+    }
+
+    @Test
+    fun salesScreen_showsNoSalesMessageWhenListIsEmptyAndNotLoading() {
+        mockUiState.value = SalesUiState(sales = emptyList(), isLoading = false)
+        composeTestRule.onNodeWithText("No sales transactions found.").assertIsDisplayed()
+    }
+
+    @Test
+    fun fabClick_callsViewModelRecordNewSalePlaceholder() {
+        composeTestRule.onNodeWithContentDescription("Record New Sale").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Record New Sale").performClick()
+        verify(mockViewModel).recordNewSalePlaceholder()
+    }
+
+    @Test
+    fun saleItemClick_callsViewModelViewSaleDetailsPlaceholder() {
+        val firstSale = sampleSales.first()
+        // Click on the Card containing the first sale's transaction ID
+        composeTestRule.onNodeWithText("ID: ${firstSale.transactionId}").performClick()
+        verify(mockViewModel).viewSaleDetailsPlaceholder(firstSale.id)
+    }
+
+    @Test
+    fun userMessageInUiState_triggersLaunchedEffectAndCallsOnUserMessageShown() {
+        mockUiState.value = SalesUiState(sales = sampleSales, userMessage = "Test Sales Message")
+
+        composeTestRule.runOnIdle { // Ensure composition and effects have settled
+            verify(mockViewModel).onUserMessageShown()
+        }
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/sales/SalesViewModel.kt
+++ b/app/src/main/java/com/example/store/presentation/sales/SalesViewModel.kt
@@ -1,0 +1,105 @@
+package com.example.store.presentation.sales
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.store.presentation.sales.model.SaleItemUi
+import com.example.store.presentation.sales.model.SoldItemSimple
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class SalesUiState(
+    val sales: List<SaleItemUi> = emptyList(),
+    val isLoading: Boolean = false,
+    val userMessage: String? = null
+)
+
+class SalesViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SalesUiState())
+    val uiState: StateFlow<SalesUiState> = _uiState.asStateFlow()
+
+    init {
+        loadSalesHistory()
+    }
+
+    private fun loadSalesHistory() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            kotlinx.coroutines.delay(1000) // Simulate data loading
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    sales = createMockSales()
+                )
+            }
+        }
+    }
+
+    fun recordNewSalePlaceholder() {
+        _uiState.update {
+            it.copy(userMessage = "Record New Sale action triggered (Placeholder).")
+        }
+    }
+
+    fun viewSaleDetailsPlaceholder(saleId: String) {
+        val sale = _uiState.value.sales.find { it.id == saleId }
+        _uiState.update {
+            it.copy(
+                userMessage = sale?.let { s ->
+                    "Viewing details for sale ${s.transactionId} (Placeholder)."
+                } ?: "Sale not found."
+            )
+        }
+    }
+
+    fun onUserMessageShown() {
+        _uiState.update { it.copy(userMessage = null) }
+    }
+
+    private fun createMockSales(): List<SaleItemUi> {
+        val currentTime = System.currentTimeMillis()
+        return listOf(
+            SaleItemUi(
+                itemsSoldSummary = "Apples (2), Milk (1)",
+                items = listOf(
+                    SoldItemSimple("Apples", 2, 0.5),
+                    SoldItemSimple("Milk (1L)", 1, 1.2)
+                ),
+                totalAmount = (2 * 0.5) + (1 * 1.2),
+                saleDate = currentTime - (1 * 24 * 60 * 60 * 1000), // 1 day ago
+                customerName = "John Doe"
+            ),
+            SaleItemUi(
+                itemsSoldSummary = "Bread (1), Eggs (1 dozen)",
+                items = listOf(
+                    SoldItemSimple("Bread Loaf", 1, 2.0),
+                    SoldItemSimple("Eggs (dozen)", 1, 2.5)
+                ),
+                totalAmount = 2.0 + 2.5,
+                saleDate = currentTime - (2 * 60 * 60 * 1000), // 2 hours ago
+                customerName = "Jane Smith"
+            ),
+            SaleItemUi(
+                itemsSoldSummary = "Chicken Breast (1kg)",
+                items = listOf(
+                    SoldItemSimple("Chicken Breast (kg)", 1, 8.0)
+                ),
+                totalAmount = 8.0,
+                saleDate = currentTime,
+                customerName = null // No customer name
+            ),
+            SaleItemUi(
+                itemsSoldSummary = "Cereal Box (1), Bananas (3)",
+                 items = listOf(
+                    SoldItemSimple("Cereal Box", 1, 3.5),
+                    SoldItemSimple("Bananas", 3, 0.3)
+                ),
+                totalAmount = 3.5 + (3*0.3),
+                saleDate = currentTime - (3 * 24 * 60 * 60 * 1000) // 3 days ago
+            )
+        ).sortedByDescending { it.saleDate }
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/sales/model/SaleItemUi.kt
+++ b/app/src/main/java/com/example/store/presentation/sales/model/SaleItemUi.kt
@@ -1,0 +1,36 @@
+package com.example.store.presentation.sales.model
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+
+// A simplified representation of an item within a sale for the summary
+data class SoldItemSimple(
+    val productName: String,
+    val quantity: Int,
+    val unitPrice: Double
+) {
+    val totalPrice: Double get() = quantity * unitPrice
+}
+
+data class SaleItemUi(
+    val id: String = UUID.randomUUID().toString(),
+    val transactionId: String = "SALE-${UUID.randomUUID().toString().take(8).uppercase()}",
+    // For simplicity in this phase, itemsSold can be a summary string or a short list.
+    // In a real app, this would be a list of SoldItem objects or references.
+    val itemsSoldSummary: String, // e.g., "Apples (2), Bananas (1)" or just "Multiple Items"
+    val items: List<SoldItemSimple> = emptyList(), // More detailed list for potential expansion
+    val totalAmount: Double,
+    val saleDate: Long = System.currentTimeMillis(),
+    val customerName: String? = null // Optional
+) {
+    fun getFormattedDate(): String {
+        val sdf = SimpleDateFormat("dd MMM yyyy, HH:mm", Locale.getDefault())
+        return sdf.format(Date(saleDate))
+    }
+
+    fun getFormattedTotalAmount(): String {
+        return String.format("$%.2f", totalAmount)
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/sales/ui/SalesScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/sales/ui/SalesScreen.kt
@@ -1,20 +1,129 @@
 package com.example.store.presentation.sales.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.store.presentation.sales.SalesViewModel
+import com.example.store.presentation.sales.model.SaleItemUi
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SalesScreen(
+    viewModel: SalesViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(key1 = uiState.userMessage) {
+        uiState.userMessage?.let {
+            Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+            viewModel.onUserMessageShown()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Sales Transactions") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = {
+                viewModel.recordNewSalePlaceholder()
+            }) {
+                Icon(Icons.Filled.Add, contentDescription = "Record New Sale")
+            }
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            if (uiState.isLoading) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            } else if (uiState.sales.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("No sales transactions found.", style = MaterialTheme.typography.bodyLarge)
+                }
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    items(uiState.sales, key = { it.id }) { sale ->
+                        SaleListItem(
+                            sale = sale,
+                            onClick = { viewModel.viewSaleDetailsPlaceholder(sale.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
 
 @Composable
-fun SalesScreen() {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+fun SaleListItem(
+    sale: SaleItemUi,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
-        Text(text = "Sales Screen")
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    "ID: ${sale.transactionId}",
+                    style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.Bold)
+                )
+                Text(
+                    sale.getFormattedDate(),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                "Items: ${sale.itemsSoldSummary}",
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 2 // Allow some wrapping for item summary
+            )
+            sale.customerName?.let {
+                Text("Customer: $it", style = MaterialTheme.typography.bodySmall)
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                "Total: ${sale.getFormattedTotalAmount()}",
+                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold),
+                modifier = Modifier.align(Alignment.End)
+            )
+        }
     }
 }

--- a/app/src/test/java/com/example/store/presentation/sales/SalesViewModelTest.kt
+++ b/app/src/test/java/com/example/store/presentation/sales/SalesViewModelTest.kt
@@ -1,0 +1,100 @@
+package com.example.store.presentation.sales
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class SalesViewModelTest {
+
+    private lateinit var viewModel: SalesViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = SalesViewModel()
+        // Advance past the init block's loadSalesHistory coroutine
+        testDispatcher.scheduler.runCurrent()
+    }
+
+    @Test
+    fun `initial state loads mock sales and sorts them`() = runTest {
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.isLoading).isFalse()
+            assertThat(emission.sales).isNotEmpty()
+            // Check for a known item from mock data
+            assertThat(emission.sales.any { it.itemsSoldSummary.contains("Apples") }).isTrue()
+            // Verify sorting (most recent first)
+            if (emission.sales.size > 1) {
+                for (i in 0 until emission.sales.size - 1) {
+                    assertThat(emission.sales[i].saleDate).isAtLeast(emission.sales[i+1].saleDate)
+                }
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `recordNewSalePlaceholder sets userMessage`() = runTest {
+        viewModel.recordNewSalePlaceholder()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isEqualTo("Record New Sale action triggered (Placeholder).")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `viewSaleDetailsPlaceholder sets userMessage for existing sale`() = runTest {
+        val firstSale = viewModel.uiState.value.sales.firstOrNull()
+        assertThat(firstSale).isNotNull()
+
+        firstSale?.let {
+            viewModel.viewSaleDetailsPlaceholder(it.id)
+            viewModel.uiState.test {
+                val emission = awaitItem()
+                assertThat(emission.userMessage).isEqualTo("Viewing details for sale ${it.transactionId} (Placeholder).")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `viewSaleDetailsPlaceholder sets userMessage for non-existent sale`() = runTest {
+        val nonExistentId = "non-existent-sale-id"
+        viewModel.viewSaleDetailsPlaceholder(nonExistentId)
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isEqualTo("Sale not found.")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onUserMessageShown clears userMessage`() = runTest {
+        // Set a message first
+        viewModel.recordNewSalePlaceholder()
+        testDispatcher.scheduler.runCurrent() // Ensure state update
+
+        assertThat(viewModel.uiState.value.userMessage).isNotNull()
+
+        viewModel.onUserMessageShown()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
- Added SaleItemUi and SoldItemSimple data classes for representing sales transactions and items.
- Implemented SalesViewModel with mock data, UiState, and placeholder functions for recording new sales and viewing details.
- Designed and implemented SalesScreen UI using Jetpack Compose, displaying a list of sales, a FAB, and click handlers for items.
- Integrated Toast messages for user feedback on actions via ViewModel state.
- Added unit tests for SalesViewModel.
- Added basic UI tests for SalesScreen.