### PR TITLE
feat: Implement basic Orders screen

### DIFF
--- a/app/src/androidTest/java/com/example/store/presentation/orders/OrdersScreenTest.kt
+++ b/app/src/androidTest/java/com/example/store/presentation/orders/OrdersScreenTest.kt
@@ -1,0 +1,124 @@
+package com.example.store.presentation.orders
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.example.store.presentation.orders.model.OrderItemUi
+import com.example.store.presentation.orders.model.OrderStatus
+import com.example.store.presentation.orders.ui.OrdersScreen
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+
+class OrdersScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var mockViewModel: OrdersViewModel
+    private val mockUiState = MutableStateFlow(OrdersUiState())
+
+    private val sampleOrders = listOf(
+        OrderItemUi(
+            id = "1",
+            orderNumber = "ORD-001",
+            customerName = "Customer Alpha",
+            status = OrderStatus.PENDING,
+            totalAmount = 100.0,
+            itemSummary = "Item A, Item B"
+        ),
+        OrderItemUi(
+            id = "2",
+            orderNumber = "ORD-002",
+            customerName = "Customer Beta",
+            status = OrderStatus.SHIPPED,
+            totalAmount = 50.0,
+            itemSummary = "Item C"
+        )
+    )
+
+    @Before
+    fun setUp() {
+        mockViewModel = mock<OrdersViewModel> {
+            on { uiState } doReturn mockUiState
+        }
+        mockUiState.value = OrdersUiState(orders = sampleOrders, isLoading = false)
+
+        composeTestRule.setContent {
+            OrdersScreen(viewModel = mockViewModel)
+        }
+    }
+
+    @Test
+    fun ordersScreen_displaysItemsFromViewModel() {
+        // Test first order
+        composeTestRule.onNodeWithText("ORD-001").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Customer: Customer Alpha").assertIsDisplayed()
+        composeTestRule.onNodeWithText(OrderStatus.PENDING.getDisplayValue()).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Total: ${sampleOrders[0].getFormattedTotalAmount()}").assertIsDisplayed()
+
+        // Test second order
+        composeTestRule.onNodeWithText("ORD-002").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Customer: Customer Beta").assertIsDisplayed()
+        composeTestRule.onNodeWithText(OrderStatus.SHIPPED.getDisplayValue()).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Total: ${sampleOrders[1].getFormattedTotalAmount()}").assertIsDisplayed()
+    }
+
+    @Test
+    fun ordersScreen_showsLoadingIndicatorWhenLoading() {
+        mockUiState.value = OrdersUiState(isLoading = true)
+        composeTestRule.onNodeWithText("ORD-001").assertDoesNotExist()
+        // Add a more specific check for the loading indicator if it has a testTag
+    }
+
+    @Test
+    fun ordersScreen_showsNoOrdersMessageWhenListIsEmptyAndNotLoading() {
+        mockUiState.value = OrdersUiState(orders = emptyList(), isLoading = false)
+        composeTestRule.onNodeWithText("No orders found.").assertIsDisplayed()
+    }
+
+    @Test
+    fun fabClick_callsViewModelCreateNewOrderPlaceholder() {
+        composeTestRule.onNodeWithContentDescription("Create New Order").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Create New Order").performClick()
+        verify(mockViewModel).createNewOrderPlaceholder()
+    }
+
+    @Test
+    fun orderItemClick_callsViewModelViewOrderDetailsPlaceholder() {
+        val firstOrder = sampleOrders.first()
+        composeTestRule.onNodeWithText(firstOrder.orderNumber).performClick() // Click the card via order number text
+        verify(mockViewModel).viewOrderDetailsPlaceholder(firstOrder.id)
+    }
+
+    @Test
+    fun statusMenuClick_opensMenuAndItemClickCallsViewModelUpdateStatus() {
+        val firstOrder = sampleOrders.first()
+        val newStatus = OrderStatus.PROCESSING
+
+        // Click the "MoreVert" icon for the first order
+        composeTestRule.onNodeWithContentDescription("Update status for ${firstOrder.orderNumber}")
+            .assertIsDisplayed()
+            .performClick()
+
+        // Menu should be open, click on the new status
+        composeTestRule.onNodeWithText(newStatus.getDisplayValue())
+            .assertIsDisplayed()
+            .performClick()
+
+        // Verify ViewModel was called
+        verify(mockViewModel).updateOrderStatusPlaceholder(firstOrder.id, newStatus)
+    }
+
+    @Test
+    fun userMessageInUiState_triggersLaunchedEffectAndCallsOnUserMessageShown() {
+        mockUiState.value = OrdersUiState(orders = sampleOrders, userMessage = "Test Order Message")
+
+        composeTestRule.runOnIdle {
+            verify(mockViewModel).onUserMessageShown()
+        }
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/orders/OrdersViewModel.kt
+++ b/app/src/main/java/com/example/store/presentation/orders/OrdersViewModel.kt
@@ -1,0 +1,128 @@
+package com.example.store.presentation.orders
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.store.presentation.orders.model.OrderItemUi
+import com.example.store.presentation.orders.model.OrderStatus
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class OrdersUiState(
+    val orders: List<OrderItemUi> = emptyList(),
+    val isLoading: Boolean = false,
+    val userMessage: String? = null
+)
+
+class OrdersViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(OrdersUiState())
+    val uiState: StateFlow<OrdersUiState> = _uiState.asStateFlow()
+
+    init {
+        loadOrders()
+    }
+
+    private fun loadOrders() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            kotlinx.coroutines.delay(1000) // Simulate data loading
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    orders = createMockOrders()
+                )
+            }
+        }
+    }
+
+    fun createNewOrderPlaceholder() {
+        _uiState.update {
+            it.copy(userMessage = "Create New Order action triggered (Placeholder).")
+        }
+    }
+
+    fun viewOrderDetailsPlaceholder(orderId: String) {
+        val order = _uiState.value.orders.find { it.id == orderId }
+        _uiState.update {
+            it.copy(
+                userMessage = order?.let { o ->
+                    "Viewing details for order ${o.orderNumber} (Placeholder)."
+                } ?: "Order not found."
+            )
+        }
+    }
+
+    fun updateOrderStatusPlaceholder(orderId: String, newStatus: OrderStatus) {
+        // In a real app, this would also update the backend.
+        // For now, we'll just update the local list and show a message.
+        val currentOrders = _uiState.value.orders
+        val updatedOrders = currentOrders.map { order ->
+            if (order.id == orderId) {
+                order.copy(status = newStatus)
+            } else {
+                order
+            }
+        }
+        if (currentOrders != updatedOrders) {
+             _uiState.update {
+                it.copy(
+                    orders = updatedOrders,
+                    userMessage = "Order ${updatedOrders.find{it.id == orderId}?.orderNumber} status updated to ${newStatus.getDisplayValue()} (Placeholder)."
+                )
+            }
+        } else {
+             _uiState.update {
+                it.copy(userMessage = "Failed to update status for order ID $orderId (not found).")
+            }
+        }
+    }
+
+
+    fun onUserMessageShown() {
+        _uiState.update { it.copy(userMessage = null) }
+    }
+
+    private fun createMockOrders(): List<OrderItemUi> {
+        val currentTime = System.currentTimeMillis()
+        return listOf(
+            OrderItemUi(
+                customerName = "Alice Wonderland",
+                orderDate = currentTime - (3 * 24 * 60 * 60 * 1000), // 3 days ago
+                status = OrderStatus.DELIVERED,
+                totalAmount = 75.50,
+                itemSummary = "Books (2), Tea Set (1)"
+            ),
+            OrderItemUi(
+                customerName = "Bob The Builder",
+                orderDate = currentTime - (1 * 24 * 60 * 60 * 1000), // 1 day ago
+                status = OrderStatus.SHIPPED,
+                totalAmount = 120.00,
+                itemSummary = "Toolbox (1), Hammer (5), Nails (box)"
+            ),
+            OrderItemUi(
+                customerName = "Charlie Brown",
+                orderDate = currentTime - (2 * 60 * 60 * 1000), // 2 hours ago
+                status = OrderStatus.PROCESSING,
+                totalAmount = 30.25,
+                itemSummary = "Kite (1), Comic Book (3)"
+            ),
+            OrderItemUi(
+                customerName = "Diana Prince",
+                orderDate = currentTime, // Just now
+                status = OrderStatus.PENDING,
+                totalAmount = 250.00,
+                itemSummary = "Invisible Jet Parts (3), Lasso (1)"
+            ),
+             OrderItemUi(
+                customerName = "Edward Scissorhands",
+                orderDate = currentTime - (5 * 24 * 60 * 60 * 1000), // 5 days ago
+                status = OrderStatus.CANCELED,
+                totalAmount = 55.75,
+                itemSummary = "Gloves (10 pairs) - Canceled"
+            )
+        ).sortedByDescending { it.orderDate }
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/orders/model/OrderItemUi.kt
+++ b/app/src/main/java/com/example/store/presentation/orders/model/OrderItemUi.kt
@@ -1,0 +1,38 @@
+package com.example.store.presentation.orders.model
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+
+enum class OrderStatus {
+    PENDING,
+    PROCESSING,
+    SHIPPED,
+    DELIVERED,
+    CANCELED;
+
+    // Helper to get a user-friendly string
+    fun getDisplayValue(): String {
+        return this.name.lowercase().replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+    }
+}
+
+data class OrderItemUi(
+    val id: String = UUID.randomUUID().toString(),
+    val orderNumber: String = "ORD-${UUID.randomUUID().toString().take(8).uppercase()}",
+    val customerName: String,
+    val orderDate: Long = System.currentTimeMillis(),
+    val status: OrderStatus = OrderStatus.PENDING,
+    val totalAmount: Double,
+    val itemSummary: String // e.g., "3 items: Apple, Banana, Milk"
+) {
+    fun getFormattedDate(): String {
+        val sdf = SimpleDateFormat("dd MMM yyyy, HH:mm", Locale.getDefault())
+        return sdf.format(Date(orderDate))
+    }
+
+    fun getFormattedTotalAmount(): String {
+        return String.format("$%.2f", totalAmount)
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/orders/ui/OrdersScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/orders/ui/OrdersScreen.kt
@@ -1,20 +1,187 @@
 package com.example.store.presentation.orders.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.store.presentation.orders.OrdersViewModel
+import com.example.store.presentation.orders.model.OrderItemUi
+import com.example.store.presentation.orders.model.OrderStatus
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OrdersScreen(
+    viewModel: OrdersViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(key1 = uiState.userMessage) {
+        uiState.userMessage?.let {
+            Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+            viewModel.onUserMessageShown()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Customer Orders") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = {
+                viewModel.createNewOrderPlaceholder()
+            }) {
+                Icon(Icons.Filled.Add, contentDescription = "Create New Order")
+            }
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp, vertical = 8.dp) // Adjusted padding
+        ) {
+            if (uiState.isLoading) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            } else if (uiState.orders.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("No orders found.", style = MaterialTheme.typography.bodyLarge)
+                }
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    items(uiState.orders, key = { it.id }) { order ->
+                        OrderListItem(
+                            order = order,
+                            onItemClick = { viewModel.viewOrderDetailsPlaceholder(order.id) },
+                            onStatusUpdate = { newStatus -> viewModel.updateOrderStatusPlaceholder(order.id, newStatus)}
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
 
 @Composable
-fun OrdersScreen() {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+fun OrderListItem(
+    order: OrderItemUi,
+    onItemClick: () -> Unit,
+    onStatusUpdate: (OrderStatus) -> Unit // Callback to update status
+) {
+    var showStatusMenu by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onItemClick() },
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
-        Text(text = "Orders Screen")
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth()
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    order.orderNumber,
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+                )
+                StatusIndicator(status = order.status)
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text("Customer: ${order.customerName}", style = MaterialTheme.typography.bodyMedium)
+            Text("Date: ${order.getFormattedDate()}", style = MaterialTheme.typography.bodySmall)
+            Text("Summary: ${order.itemSummary}", style = MaterialTheme.typography.bodySmall, maxLines = 2)
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "Total: ${order.getFormattedTotalAmount()}",
+                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.SemiBold)
+                )
+                Box {
+                    IconButton(onClick = { showStatusMenu = true }) {
+                        Icon(Icons.Filled.MoreVert, contentDescription = "Update status for ${order.orderNumber}")
+                    }
+                    DropdownMenu(
+                        expanded = showStatusMenu,
+                        onDismissRequest = { showStatusMenu = false }
+                    ) {
+                        OrderStatus.values().forEach { status ->
+                            DropdownMenuItem(
+                                text = { Text(status.getDisplayValue()) },
+                                onClick = {
+                                    onStatusUpdate(status)
+                                    showStatusMenu = false
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun StatusIndicator(status: OrderStatus) {
+    val backgroundColor = when (status) {
+        OrderStatus.PENDING -> Color.LightGray
+        OrderStatus.PROCESSING -> Color(0xFFFFF9C4) // Light Yellow
+        OrderStatus.SHIPPED -> Color(0xFFBBDEFB) // Light Blue
+        OrderStatus.DELIVERED -> Color(0xFFC8E6C9) // Light Green
+        OrderStatus.CANCELED -> Color(0xFFFFCDD2) // Light Red
+    }
+    val textColor = when (status) {
+        OrderStatus.PENDING -> Color.DarkGray
+        OrderStatus.PROCESSING -> Color(0xFF795548) // Brownish
+        OrderStatus.SHIPPED -> Color(0xFF0D47A1) // Dark Blue
+        OrderStatus.DELIVERED -> Color(0xFF1B5E20) // Dark Green
+        OrderStatus.CANCELED -> Color(0xFFB71C1C) // Dark Red
+    }
+
+    Box(
+        modifier = Modifier
+            .clip(CircleShape)
+            .background(backgroundColor)
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+    ) {
+        Text(
+            text = status.getDisplayValue(),
+            color = textColor,
+            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold)
+        )
     }
 }

--- a/app/src/test/java/com/example/store/presentation/orders/OrdersViewModelTest.kt
+++ b/app/src/test/java/com/example/store/presentation/orders/OrdersViewModelTest.kt
@@ -1,0 +1,131 @@
+package com.example.store.presentation.orders
+
+import app.cash.turbine.test
+import com.example.store.presentation.orders.model.OrderStatus
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class OrdersViewModelTest {
+
+    private lateinit var viewModel: OrdersViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = OrdersViewModel()
+        testDispatcher.scheduler.runCurrent() // Process initial load
+    }
+
+    @Test
+    fun `initial state loads mock orders and sorts them`() = runTest {
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.isLoading).isFalse()
+            assertThat(emission.orders).isNotEmpty()
+            assertThat(emission.orders.any { it.customerName == "Alice Wonderland" }).isTrue()
+            // Verify sorting (most recent first)
+            if (emission.orders.size > 1) {
+                for (i in 0 until emission.orders.size - 1) {
+                    assertThat(emission.orders[i].orderDate).isAtLeast(emission.orders[i+1].orderDate)
+                }
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `createNewOrderPlaceholder sets userMessage`() = runTest {
+        viewModel.createNewOrderPlaceholder()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isEqualTo("Create New Order action triggered (Placeholder).")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `viewOrderDetailsPlaceholder sets userMessage for existing order`() = runTest {
+        val firstOrder = viewModel.uiState.value.orders.firstOrNull()
+        assertThat(firstOrder).isNotNull()
+
+        firstOrder?.let {
+            viewModel.viewOrderDetailsPlaceholder(it.id)
+            viewModel.uiState.test {
+                val emission = awaitItem()
+                assertThat(emission.userMessage).isEqualTo("Viewing details for order ${it.orderNumber} (Placeholder).")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `viewOrderDetailsPlaceholder sets userMessage for non-existent order`() = runTest {
+        val nonExistentId = "non-existent-order-id"
+        viewModel.viewOrderDetailsPlaceholder(nonExistentId)
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isEqualTo("Order not found.")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `updateOrderStatusPlaceholder updates status and sets userMessage for existing order`() = runTest {
+        val orderToUpdate = viewModel.uiState.value.orders.firstOrNull { it.status != OrderStatus.SHIPPED }
+        assertThat(orderToUpdate).isNotNull()
+
+        orderToUpdate?.let {
+            val newStatus = OrderStatus.SHIPPED
+            viewModel.updateOrderStatusPlaceholder(it.id, newStatus)
+            viewModel.uiState.test {
+                val emission = awaitItem()
+                val updatedOrderInState = emission.orders.find { o -> o.id == it.id }
+                assertThat(updatedOrderInState?.status).isEqualTo(newStatus)
+                assertThat(emission.userMessage).isEqualTo("Order ${updatedOrderInState?.orderNumber} status updated to ${newStatus.getDisplayValue()} (Placeholder).")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `updateOrderStatusPlaceholder sets userMessage for non-existent order`() = runTest {
+        val nonExistentId = "non-existent-order-id-for-status-update"
+        val newStatus = OrderStatus.DELIVERED
+        viewModel.updateOrderStatusPlaceholder(nonExistentId, newStatus)
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isEqualTo("Failed to update status for order ID $nonExistentId (not found).")
+            // Also ensure no order status actually changed
+            val orderWithNewStatus = emission.orders.find { it.status == newStatus && it.id == nonExistentId}
+            assertThat(orderWithNewStatus).isNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+
+    @Test
+    fun `onUserMessageShown clears userMessage`() = runTest {
+        viewModel.createNewOrderPlaceholder()
+        testDispatcher.scheduler.runCurrent()
+        assertThat(viewModel.uiState.value.userMessage).isNotNull()
+
+        viewModel.onUserMessageShown()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
- Added OrderItemUi data class and OrderStatus enum for representing orders and their states.
- Implemented OrdersViewModel with mock data, UiState, and placeholder functions for creating new orders, viewing details, and updating status.
- Designed and implemented OrdersScreen UI using Jetpack Compose, displaying a list of orders with status indicators, a FAB, and a dropdown menu for status updates.
- Integrated Toast messages for user feedback on actions via ViewModel state.
- Added unit tests for OrdersViewModel.
- Added basic UI tests for OrdersScreen.