### PR TITLE
feat: Implement basic Scanner screen UI and placeholder logic

### DIFF
--- a/app/src/androidTest/java/com/example/store/presentation/scanner/ScannerScreenTest.kt
+++ b/app/src/androidTest/java/com/example/store/presentation/scanner/ScannerScreenTest.kt
@@ -1,0 +1,115 @@
+package com.example.store.presentation.scanner
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.example.store.presentation.scanner.model.ScannedDataUi
+import com.example.store.presentation.scanner.ui.ScannerScreen
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.times
+
+class ScannerScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var mockViewModel: ScannerViewModel
+    private val mockUiState = MutableStateFlow(ScannerUiState())
+
+    private val sampleScan1 = ScannedDataUi(content = "SCAN-001")
+    private val sampleScan2 = ScannedDataUi(content = "SCAN-002")
+
+    @Before
+    fun setUp() {
+        mockViewModel = mock<ScannerViewModel> {
+            on { uiState } doReturn mockUiState
+        }
+        // Initial state for most tests
+        mockUiState.value = ScannerUiState(lastScannedItem = null, scanHistory = emptyList())
+
+        composeTestRule.setContent {
+            ScannerScreen(viewModel = mockViewModel)
+        }
+    }
+
+    @Test
+    fun scannerScreen_initialState_displaysCorrectly() {
+        composeTestRule.onNodeWithText("Barcode Scanner").assertIsDisplayed() // TopBar
+        composeTestRule.onNodeWithContentDescription("Scanner Area").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Start Scan").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Simulate Scan").assertIsDisplayed()
+        composeTestRule.onNodeWithText("No code scanned yet.").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Scan history is empty.").assertIsDisplayed()
+    }
+
+    @Test
+    fun startScanButtonClick_callsViewModelStartScan_andChangesButtonTextToCancel() {
+        composeTestRule.onNodeWithText("Start Scan").performClick()
+        verify(mockViewModel).startScan()
+
+        // Simulate ViewModel updating isScanningActive to true
+        mockUiState.value = mockUiState.value.copy(isScanningActive = true)
+        composeTestRule.onNodeWithText("Cancel Scan").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Scanning...").assertIsDisplayed() // Check for scanning indicator text
+    }
+
+    @Test
+    fun cancelScanButtonClick_callsViewModelCancelScan_andChangesButtonTextToStart() {
+        // First, set state to scanning
+        mockUiState.value = mockUiState.value.copy(isScanningActive = true)
+        composeTestRule.onNodeWithText("Cancel Scan").assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("Cancel Scan").performClick()
+        verify(mockViewModel).cancelScan()
+
+        // Simulate ViewModel updating isScanningActive to false
+        mockUiState.value = mockUiState.value.copy(isScanningActive = false)
+        composeTestRule.onNodeWithText("Start Scan").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Scanner Area").assertIsDisplayed() // Camera icon should be back
+    }
+
+    @Test
+    fun simulateScanButtonClick_callsViewModelProcessScannedCode() {
+        composeTestRule.onNodeWithText("Simulate Scan").performClick()
+        // Verify with any string as the code is random in UI; actual verification is on VM method
+        verify(mockViewModel).processScannedCode(org.mockito.kotlin.any())
+    }
+
+    @Test
+    fun lastScannedItem_displayedCorrectly_andClearButtonWorks() {
+        mockUiState.value = mockUiState.value.copy(lastScannedItem = sampleScan1)
+
+        composeTestRule.onNodeWithText(sampleScan1.content).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Scanned: ${sampleScan1.getFormattedTimestamp()}").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Clear Last Scan").assertIsDisplayed().performClick()
+        verify(mockViewModel).clearLastScan()
+    }
+
+    @Test
+    fun scanHistory_displayedCorrectly_andClearHistoryButtonWorks() {
+        mockUiState.value = mockUiState.value.copy(scanHistory = listOf(sampleScan1, sampleScan2))
+
+        composeTestRule.onNodeWithText("Scan History (2)").assertIsDisplayed()
+        // Check for items in history (compact view)
+        composeTestRule.onNodeWithText(sampleScan1.content, substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText(sampleScan2.content, substring = true).assertIsDisplayed()
+
+        composeTestRule.onNodeWithContentDescription("Clear Scan History").assertIsDisplayed().performClick()
+        verify(mockViewModel).clearScanHistory()
+    }
+
+
+    @Test
+    fun userMessageInUiState_triggersLaunchedEffectAndCallsOnUserMessageShown() {
+        mockUiState.value = mockUiState.value.copy(userMessage = "Test Scanner Message")
+
+        composeTestRule.runOnIdle {
+            verify(mockViewModel).onUserMessageShown()
+        }
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/scanner/ScannerViewModel.kt
+++ b/app/src/main/java/com/example/store/presentation/scanner/ScannerViewModel.kt
@@ -1,0 +1,105 @@
+package com.example.store.presentation.scanner
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.store.presentation.scanner.model.ScannedDataUi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class ScannerUiState(
+    val lastScannedItem: ScannedDataUi? = null,
+    val scanHistory: List<ScannedDataUi> = emptyList(),
+    val isScanningActive: Boolean = false, // To potentially change UI while "scanning"
+    val userMessage: String? = null
+)
+
+class ScannerViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ScannerUiState())
+    val uiState: StateFlow<ScannerUiState> = _uiState.asStateFlow()
+
+    // Maximum items to keep in history
+    private val maxHistorySize = 10
+
+    fun startScan() {
+        // In a real app, this would trigger camera permission checks and launch a scanner intent/library.
+        // For now, it's a placeholder.
+        _uiState.update {
+            it.copy(
+                isScanningActive = true, // Potentially useful for UI changes
+                userMessage = "Scan started... (Point camera at a code - Placeholder)"
+            )
+        }
+        // Simulate a scan happening after a short delay for placeholder behavior
+        // viewModelScope.launch {
+        //     kotlinx.coroutines.delay(2000) // Simulate time taken to scan
+        //     if (_uiState.value.isScanningActive) { // Check if still "scanning"
+        //         processScannedCode("SIMULATED-CODE-${(1000..9999).random()}")
+        //     }
+        // }
+    }
+
+    fun processScannedCode(code: String) {
+        val newScan = ScannedDataUi(content = code)
+        val updatedHistory = (_uiState.value.scanHistory + newScan).takeLast(maxHistorySize)
+
+        _uiState.update {
+            it.copy(
+                lastScannedItem = newScan,
+                scanHistory = updatedHistory,
+                isScanningActive = false, // Turn off "scanning" state
+                userMessage = "Scanned: $code"
+            )
+        }
+    }
+
+    fun cancelScan() {
+        // If the user cancels the scanning process
+        if (_uiState.value.isScanningActive) {
+            _uiState.update {
+                it.copy(
+                    isScanningActive = false,
+                    userMessage = "Scan cancelled."
+                )
+            }
+        }
+    }
+
+    fun clearLastScan() {
+        if (_uiState.value.lastScannedItem != null) {
+            _uiState.update {
+                it.copy(
+                    lastScannedItem = null,
+                    userMessage = "Last scan cleared."
+                )
+            }
+        } else {
+            _uiState.update {
+                it.copy(userMessage = "Nothing to clear.")
+            }
+        }
+    }
+
+    fun clearScanHistory() {
+        if (_uiState.value.scanHistory.isNotEmpty()) {
+            _uiState.update {
+                it.copy(
+                    scanHistory = emptyList(),
+                    lastScannedItem = null, // Often you'd clear the last scan too if history is wiped
+                    userMessage = "Scan history cleared."
+                )
+            }
+        } else {
+             _uiState.update {
+                it.copy(userMessage = "Scan history is already empty.")
+            }
+        }
+    }
+
+    fun onUserMessageShown() {
+        _uiState.update { it.copy(userMessage = null) }
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/scanner/model/ScannedDataUi.kt
+++ b/app/src/main/java/com/example/store/presentation/scanner/model/ScannedDataUi.kt
@@ -1,0 +1,17 @@
+package com.example.store.presentation.scanner.model
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+
+data class ScannedDataUi(
+    val id: String = UUID.randomUUID().toString(),
+    val content: String,
+    val timestamp: Long = System.currentTimeMillis()
+) {
+    fun getFormattedTimestamp(): String {
+        val sdf = SimpleDateFormat("dd MMM yyyy, HH:mm:ss", Locale.getDefault())
+        return sdf.format(Date(timestamp))
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/scanner/ui/ScannerScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/scanner/ui/ScannerScreen.kt
@@ -1,20 +1,177 @@
 package com.example.store.presentation.scanner.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.store.presentation.scanner.ScannerViewModel
+import com.example.store.presentation.scanner.model.ScannedDataUi
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScannerScreen(
+    viewModel: ScannerViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(key1 = uiState.userMessage) {
+        uiState.userMessage?.let {
+            Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+            viewModel.onUserMessageShown()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Barcode Scanner") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            // Placeholder for Camera Preview / Scanning Area
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp)
+                    .border(BorderStroke(2.dp, MaterialTheme.colorScheme.primary), shape = MaterialTheme.shapes.medium),
+                contentAlignment = Alignment.Center
+            ) {
+                if (uiState.isScanningActive) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        CircularProgressIndicator()
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Text("Scanning...", style = MaterialTheme.typography.titleMedium)
+                    }
+                } else {
+                    Icon(
+                        Icons.Filled.CameraAlt,
+                        contentDescription = "Scanner Area",
+                        modifier = Modifier.size(80.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+
+            // Action Buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                Button(
+                    onClick = {
+                        if (uiState.isScanningActive) viewModel.cancelScan() else viewModel.startScan()
+                    }
+                ) {
+                    Text(if (uiState.isScanningActive) "Cancel Scan" else "Start Scan")
+                }
+                // Simulate a scan for testing UI without actual camera
+                Button(onClick = { viewModel.processScannedCode("TEST-CODE-${(100..999).random()}") }) {
+                    Text("Simulate Scan")
+                }
+            }
+
+            // Last Scanned Info
+            Text(
+                text = "Last Scanned:",
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+            )
+            uiState.lastScannedItem?.let {
+                ScannedDataItemView(item = it)
+                Button(
+                    onClick = { viewModel.clearLastScan() },
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.outlinedButtonColors()
+                ) {
+                    Text("Clear Last Scan")
+                }
+            } ?: Text("No code scanned yet.", style = MaterialTheme.typography.bodyLarge)
+
+
+            // Scan History (Optional - basic version)
+            if (uiState.scanHistory.isNotEmpty()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "Scan History (${uiState.scanHistory.size})",
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
+                    )
+                    IconButton(onClick = { viewModel.clearScanHistory() }) {
+                        Icon(Icons.Filled.Refresh, contentDescription = "Clear Scan History", tint = MaterialTheme.colorScheme.error)
+                    }
+                }
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f) // Takes remaining space
+                ) {
+                    items(uiState.scanHistory.reversed()) { item -> // Show newest first
+                        ScannedDataItemView(item = item, isCompact = true)
+                        Divider()
+                    }
+                }
+            } else {
+                 Text("Scan history is empty.", style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}
 
 @Composable
-fun ScannerScreen() {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+fun ScannedDataItemView(item: ScannedDataUi, isCompact: Boolean = false) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = if (isCompact) 4.dp else 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = if (isCompact) 1.dp else 2.dp)
     ) {
-        Text(text = "Scanner Screen")
+        Column(modifier = Modifier.padding(if (isCompact) 8.dp else 16.dp)) {
+            Text(
+                text = item.content,
+                style = if (isCompact) MaterialTheme.typography.bodyMedium else MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(if (isCompact) 2.dp else 4.dp))
+            Text(
+                text = "Scanned: ${item.getFormattedTimestamp()}",
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.Gray,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
     }
 }

--- a/app/src/test/java/com/example/store/presentation/scanner/ScannerViewModelTest.kt
+++ b/app/src/test/java/com/example/store/presentation/scanner/ScannerViewModelTest.kt
@@ -1,0 +1,184 @@
+package com.example.store.presentation.scanner
+
+import app.cash.turbine.test
+import com.example.store.presentation.scanner.model.ScannedDataUi
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class ScannerViewModelTest {
+
+    private lateinit var viewModel: ScannerViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = ScannerViewModel()
+        // No initial loading, so no need to advance dispatcher here for init
+    }
+
+    @Test
+    fun `initial state is correct`() = runTest {
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.lastScannedItem).isNull()
+            assertThat(emission.scanHistory).isEmpty()
+            assertThat(emission.isScanningActive).isFalse()
+            assertThat(emission.userMessage).isNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `startScan updates state and userMessage`() = runTest {
+        viewModel.startScan()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.isScanningActive).isTrue()
+            assertThat(emission.userMessage).isEqualTo("Scan started... (Point camera at a code - Placeholder)")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `processScannedCode updates lastScannedItem, history, and userMessage`() = runTest {
+        val testCode = "TEST12345"
+        viewModel.processScannedCode(testCode)
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.lastScannedItem).isNotNull()
+            assertThat(emission.lastScannedItem?.content).isEqualTo(testCode)
+            assertThat(emission.scanHistory).hasSize(1)
+            assertThat(emission.scanHistory.first().content).isEqualTo(testCode)
+            assertThat(emission.isScanningActive).isFalse() // Should turn off after processing
+            assertThat(emission.userMessage).isEqualTo("Scanned: $testCode")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `processScannedCode respects max history size`() = runTest {
+        val maxHistory = 10 // As defined in ViewModel
+        for (i in 1..(maxHistory + 5)) {
+            viewModel.processScannedCode("CODE-$i")
+            testDispatcher.scheduler.runCurrent() // ensure updates are processed for each item
+        }
+
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.scanHistory).hasSize(maxHistory)
+            assertThat(emission.scanHistory.first().content).isEqualTo("CODE-6") // Oldest item should be CODE-6
+            assertThat(emission.scanHistory.last().content).isEqualTo("CODE-15") // Newest item
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `cancelScan updates state and userMessage if scanning was active`() = runTest {
+        viewModel.startScan() // Make scanning active
+        testDispatcher.scheduler.runCurrent()
+
+        viewModel.cancelScan()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.isScanningActive).isFalse()
+            assertThat(emission.userMessage).isEqualTo("Scan cancelled.")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `cancelScan does nothing if scanning was not active`() = runTest {
+        // Initial state is not scanning
+        val initialState = viewModel.uiState.value
+        viewModel.cancelScan()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission).isEqualTo(initialState) // State should not change
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+
+    @Test
+    fun `clearLastScan clears item and sets userMessage if item exists`() = runTest {
+        viewModel.processScannedCode("ANYCODE")
+        testDispatcher.scheduler.runCurrent()
+        assertThat(viewModel.uiState.value.lastScannedItem).isNotNull()
+
+        viewModel.clearLastScan()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.lastScannedItem).isNull()
+            assertThat(emission.userMessage).isEqualTo("Last scan cleared.")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `clearLastScan sets message if no item to clear`() = runTest {
+        assertThat(viewModel.uiState.value.lastScannedItem).isNull()
+        viewModel.clearLastScan()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isEqualTo("Nothing to clear.")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `clearScanHistory clears history and last scan, sets userMessage`() = runTest {
+        viewModel.processScannedCode("CODE1")
+        testDispatcher.scheduler.runCurrent()
+        viewModel.processScannedCode("CODE2")
+        testDispatcher.scheduler.runCurrent()
+
+        assertThat(viewModel.uiState.value.scanHistory).isNotEmpty()
+        assertThat(viewModel.uiState.value.lastScannedItem).isNotNull()
+
+        viewModel.clearScanHistory()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.scanHistory).isEmpty()
+            assertThat(emission.lastScannedItem).isNull()
+            assertThat(emission.userMessage).isEqualTo("Scan history cleared.")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `clearScanHistory sets message if history already empty`() = runTest {
+        assertThat(viewModel.uiState.value.scanHistory).isEmpty()
+        viewModel.clearScanHistory()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isEqualTo("Scan history is already empty.")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `onUserMessageShown clears userMessage`() = runTest {
+        viewModel.startScan() // This sets a user message
+        testDispatcher.scheduler.runCurrent()
+        assertThat(viewModel.uiState.value.userMessage).isNotNull()
+
+        viewModel.onUserMessageShown()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
- Added ScannedDataUi data class for representing scanned information.
- Implemented ScannerViewModel with UiState for last scan, scan history, and scanning status, including placeholder functions for scan operations and clearing data.
- Designed and implemented ScannerScreen UI with a camera placeholder, scan/cancel/simulate buttons, display for last scan, and a scan history list.
- Integrated Toast messages for user feedback via ViewModel state.
- Added unit tests for ScannerViewModel.
- Added basic UI tests for ScannerScreen.