### PR TITLE
feat: Implement basic Expenses screen

### DIFF
--- a/app/src/androidTest/java/com/example/store/presentation/expenses/ExpensesScreenTest.kt
+++ b/app/src/androidTest/java/com/example/store/presentation/expenses/ExpensesScreenTest.kt
@@ -1,0 +1,102 @@
+package com.example.store.presentation.expenses
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.example.store.presentation.expenses.model.ExpenseItemUi
+import com.example.store.presentation.expenses.ui.ExpensesScreen
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+
+class ExpensesScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var mockViewModel: ExpensesViewModel
+    private val mockUiState = MutableStateFlow(ExpensesUiState())
+
+    private val sampleExpenses = listOf(
+        ExpenseItemUi(id = "1", description = "Office Rent", category = "Rent", amount = 1200.0, vendor = "Big Corp"),
+        ExpenseItemUi(id = "2", description = "Electricity Bill", category = "Utilities", amount = 150.0)
+    )
+    private val sampleTotalExpenses = sampleExpenses.sumOf { it.amount }
+
+    @Before
+    fun setUp() {
+        mockViewModel = mock<ExpensesViewModel> {
+            on { uiState } doReturn mockUiState
+        }
+        mockUiState.value = ExpensesUiState(
+            expenses = sampleExpenses,
+            isLoading = false,
+            totalExpenses = sampleTotalExpenses
+        )
+
+        composeTestRule.setContent {
+            ExpensesScreen(viewModel = mockViewModel)
+        }
+    }
+
+    @Test
+    fun expensesScreen_displaysItemsAndTotalFromViewModel() {
+        // Test Total Expenses Header
+        composeTestRule.onNodeWithText("Total Expenses").assertIsDisplayed()
+        composeTestRule.onNodeWithText(String.format("$%.2f", sampleTotalExpenses)).assertIsDisplayed()
+
+        // Test first expense item
+        composeTestRule.onNodeWithText("Office Rent").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Category: Rent").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Vendor: Big Corp").assertIsDisplayed()
+        composeTestRule.onNodeWithText(sampleExpenses[0].getFormattedAmount()).assertIsDisplayed()
+
+        // Test second expense item
+        composeTestRule.onNodeWithText("Electricity Bill").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Category: Utilities").assertIsDisplayed()
+        composeTestRule.onNodeWithText(sampleExpenses[1].getFormattedAmount()).assertIsDisplayed()
+        // Check that "Vendor:" is not displayed if vendor is null (implicitly by not finding it for second item)
+    }
+
+    @Test
+    fun expensesScreen_showsLoadingIndicatorWhenLoading() {
+        mockUiState.value = ExpensesUiState(isLoading = true, totalExpenses = 0.0) // total is also reset/not yet calc
+        composeTestRule.onNodeWithText("Office Rent").assertDoesNotExist()
+        // Check that total expenses might show 0 or not be the focus when loading
+        composeTestRule.onNodeWithText(String.format("$%.2f", 0.00)).assertIsDisplayed()
+    }
+
+    @Test
+    fun expensesScreen_showsNoExpensesMessageWhenListIsEmptyAndNotLoading() {
+        mockUiState.value = ExpensesUiState(expenses = emptyList(), isLoading = false, totalExpenses = 0.0)
+        composeTestRule.onNodeWithText("No expenses recorded yet.").assertIsDisplayed()
+        composeTestRule.onNodeWithText(String.format("$%.2f", 0.00)).assertIsDisplayed() // Total should be 0
+    }
+
+    @Test
+    fun fabClick_callsViewModelAddExpensePlaceholder() {
+        composeTestRule.onNodeWithContentDescription("Add New Expense").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Add New Expense").performClick()
+        verify(mockViewModel).addExpensePlaceholder()
+    }
+
+    @Test
+    fun expenseItemClick_callsViewModelViewExpenseDetailsPlaceholder() {
+        val firstExpense = sampleExpenses.first()
+        // Click on the Card containing the first expense's description
+        composeTestRule.onNodeWithText(firstExpense.description).performClick()
+        verify(mockViewModel).viewExpenseDetailsPlaceholder(firstExpense.id)
+    }
+
+    @Test
+    fun userMessageInUiState_triggersLaunchedEffectAndCallsOnUserMessageShown() {
+        mockUiState.value = mockUiState.value.copy(userMessage = "Test Expense Message")
+
+        composeTestRule.runOnIdle {
+            verify(mockViewModel).onUserMessageShown()
+        }
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/expenses/ExpensesViewModel.kt
+++ b/app/src/main/java/com/example/store/presentation/expenses/ExpensesViewModel.kt
@@ -1,0 +1,123 @@
+package com.example.store.presentation.expenses
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.store.presentation.expenses.model.ExpenseItemUi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class ExpensesUiState(
+    val expenses: List<ExpenseItemUi> = emptyList(),
+    val isLoading: Boolean = false,
+    val userMessage: String? = null,
+    val totalExpenses: Double = 0.0 // Calculated total
+)
+
+class ExpensesViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ExpensesUiState())
+    val uiState: StateFlow<ExpensesUiState> = _uiState.asStateFlow()
+
+    init {
+        loadExpenses()
+    }
+
+    private fun loadExpenses() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            kotlinx.coroutines.delay(1000) // Simulate data loading
+            val mockExpenses = createMockExpenses()
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    expenses = mockExpenses,
+                    totalExpenses = mockExpenses.sumOf { exp -> exp.amount }
+                )
+            }
+        }
+    }
+
+    fun addExpensePlaceholder() {
+        // In a real app, this would navigate to a new screen or show a detailed dialog
+        _uiState.update {
+            it.copy(userMessage = "Add New Expense action triggered (Placeholder).")
+        }
+    }
+
+    fun viewExpenseDetailsPlaceholder(expenseId: String) {
+        val expense = _uiState.value.expenses.find { it.id == expenseId }
+        _uiState.update {
+            it.copy(
+                userMessage = expense?.let { e ->
+                    "Viewing details for expense: '${e.description}' (Placeholder)."
+                } ?: "Expense not found."
+            )
+        }
+    }
+
+    // Example of how a real add might work, including recalculating total
+    fun addActualExpense(description: String, category: String, amount: Double, vendor: String? = null) {
+        val newExpense = ExpenseItemUi(
+            description = description,
+            category = category,
+            amount = amount,
+            vendor = vendor
+        )
+        val updatedExpenses = _uiState.value.expenses + newExpense
+        _uiState.update {
+            it.copy(
+                expenses = updatedExpenses.sortedByDescending { exp -> exp.expenseDate },
+                totalExpenses = updatedExpenses.sumOf { exp -> exp.amount },
+                userMessage = "'${newExpense.description}' added to expenses."
+            )
+        }
+    }
+
+
+    fun onUserMessageShown() {
+        _uiState.update { it.copy(userMessage = null) }
+    }
+
+    private fun createMockExpenses(): List<ExpenseItemUi> {
+        val currentTime = System.currentTimeMillis()
+        return listOf(
+            ExpenseItemUi(
+                description = "Office Rent - October",
+                category = "Rent",
+                amount = 1200.00,
+                expenseDate = currentTime - (5 * 24 * 60 * 60 * 1000), // 5 days ago
+                vendor = "City Properties LLC"
+            ),
+            ExpenseItemUi(
+                description = "Electricity Bill",
+                category = "Utilities",
+                amount = 150.75,
+                expenseDate = currentTime - (2 * 24 * 60 * 60 * 1000), // 2 days ago
+                vendor = "Power Grid Corp"
+            ),
+            ExpenseItemUi(
+                description = "Internet Services",
+                category = "Utilities",
+                amount = 79.99,
+                expenseDate = currentTime - (1 * 24 * 60 * 60 * 1000), // 1 day ago
+                vendor = "ConnectFast ISP"
+            ),
+            ExpenseItemUi(
+                description = "Stationery Supplies",
+                category = "Supplies",
+                amount = 45.50,
+                expenseDate = currentTime,
+                vendor = "Office Depot"
+            ),
+            ExpenseItemUi(
+                description = "Marketing Campaign - Q4",
+                category = "Marketing",
+                amount = 500.00,
+                expenseDate = currentTime - (10 * 24 * 60 * 60 * 1000) // 10 days ago
+            )
+        ).sortedByDescending { it.expenseDate }
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/expenses/model/ExpenseItemUi.kt
+++ b/app/src/main/java/com/example/store/presentation/expenses/model/ExpenseItemUi.kt
@@ -1,0 +1,28 @@
+package com.example.store.presentation.expenses.model
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.UUID
+
+// Consider making categories an enum if they are predefined and fixed
+// For now, a string is flexible for mock data.
+// enum class ExpenseCategory { RENT, UTILITIES, SUPPLIES, SALARIES, MARKETING, MISCELLANEOUS }
+
+data class ExpenseItemUi(
+    val id: String = UUID.randomUUID().toString(),
+    val description: String,
+    val category: String, // Could be ExpenseCategory enum later
+    val amount: Double,
+    val expenseDate: Long = System.currentTimeMillis(),
+    val vendor: String? = null // Optional: e.g., utility company, landlord
+) {
+    fun getFormattedDate(): String {
+        val sdf = SimpleDateFormat("dd MMM yyyy", Locale.getDefault()) // Simpler date for expenses
+        return sdf.format(Date(expenseDate))
+    }
+
+    fun getFormattedAmount(): String {
+        return String.format("$%.2f", amount)
+    }
+}

--- a/app/src/main/java/com/example/store/presentation/expenses/ui/ExpensesScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/expenses/ui/ExpensesScreen.kt
@@ -1,20 +1,160 @@
 package com.example.store.presentation.expenses.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import android.widget.Toast
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.store.presentation.expenses.ExpensesViewModel
+import com.example.store.presentation.expenses.model.ExpenseItemUi
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExpensesScreen(
+    viewModel: ExpensesViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    LaunchedEffect(key1 = uiState.userMessage) {
+        uiState.userMessage?.let {
+            Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
+            viewModel.onUserMessageShown()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Manage Expenses") },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = {
+                viewModel.addExpensePlaceholder()
+                // Example of calling the more complete add function:
+                // viewModel.addActualExpense("Test FAB Expense", "Test Category", 12.34, "Test Vendor")
+            }) {
+                Icon(Icons.Filled.Add, contentDescription = "Add New Expense")
+            }
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            // Summary Header
+            ExpenseSummaryHeader(totalExpenses = uiState.totalExpenses)
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (uiState.isLoading) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            } else if (uiState.expenses.isEmpty()) {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text("No expenses recorded yet.", style = MaterialTheme.typography.bodyLarge)
+                }
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    items(uiState.expenses, key = { it.id }) { expense ->
+                        ExpenseListItem(
+                            expense = expense,
+                            onClick = { viewModel.viewExpenseDetailsPlaceholder(expense.id) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
 
 @Composable
-fun ExpensesScreen() {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+fun ExpenseSummaryHeader(totalExpenses: Double) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer)
     ) {
-        Text(text = "Expenses Screen")
+        Column(
+            modifier = Modifier.padding(16.dp).fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                "Total Expenses",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer
+            )
+            Text(
+                String.format("$%.2f", totalExpenses),
+                style = MaterialTheme.typography.headlineMedium.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.onSecondaryContainer
+            )
+        }
+    }
+}
+
+
+@Composable
+fun ExpenseListItem(
+    expense: ExpenseItemUi,
+    onClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(modifier = Modifier.weight(1f).padding(end = 8.dp)) {
+                Text(
+                    expense.description,
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    maxLines = 2
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    "Category: ${expense.category}",
+                    style = MaterialTheme.typography.bodySmall
+                )
+                expense.vendor?.let {
+                    Text("Vendor: $it", style = MaterialTheme.typography.bodySmall)
+                }
+                Text(
+                    "Date: ${expense.getFormattedDate()}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            Text(
+                expense.getFormattedAmount(),
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.error // Expenses often shown in red or distinct color
+            )
+        }
     }
 }

--- a/app/src/test/java/com/example/store/presentation/expenses/ExpensesViewModelTest.kt
+++ b/app/src/test/java/com/example/store/presentation/expenses/ExpensesViewModelTest.kt
@@ -1,0 +1,134 @@
+package com.example.store.presentation.expenses
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class ExpensesViewModelTest {
+
+    private lateinit var viewModel: ExpensesViewModel
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        viewModel = ExpensesViewModel()
+        testDispatcher.scheduler.runCurrent() // Process initial load
+    }
+
+    @Test
+    fun `initial state loads mock expenses, calculates total, and sorts them`() = runTest {
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.isLoading).isFalse()
+            assertThat(emission.expenses).isNotEmpty()
+            assertThat(emission.expenses.any { it.category == "Rent" }).isTrue()
+
+            val expectedTotal = emission.expenses.sumOf { it.amount }
+            assertThat(emission.totalExpenses).isEqualTo(expectedTotal)
+
+            // Verify sorting (most recent first)
+            if (emission.expenses.size > 1) {
+                for (i in 0 until emission.expenses.size - 1) {
+                    assertThat(emission.expenses[i].expenseDate).isAtLeast(emission.expenses[i+1].expenseDate)
+                }
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `addExpensePlaceholder sets userMessage`() = runTest {
+        viewModel.addExpensePlaceholder()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isEqualTo("Add New Expense action triggered (Placeholder).")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `viewExpenseDetailsPlaceholder sets userMessage for existing expense`() = runTest {
+        val firstExpense = viewModel.uiState.value.expenses.firstOrNull()
+        assertThat(firstExpense).isNotNull()
+
+        firstExpense?.let {
+            viewModel.viewExpenseDetailsPlaceholder(it.id)
+            viewModel.uiState.test {
+                val emission = awaitItem()
+                assertThat(emission.userMessage).isEqualTo("Viewing details for expense: '${it.description}' (Placeholder).")
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun `viewExpenseDetailsPlaceholder sets userMessage for non-existent expense`() = runTest {
+        val nonExistentId = "non-existent-expense-id"
+        viewModel.viewExpenseDetailsPlaceholder(nonExistentId)
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isEqualTo("Expense not found.")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `addActualExpense adds item, updates total, sorts, and sets userMessage`() = runTest {
+        val initialExpenses = viewModel.uiState.value.expenses
+        val initialTotal = viewModel.uiState.value.totalExpenses
+
+        val newDesc = "New Test Expense"
+        val newCat = "Test Category"
+        val newAmount = 100.0
+
+        viewModel.addActualExpense(newDesc, newCat, newAmount)
+        testDispatcher.scheduler.runCurrent() // Ensure updates are processed
+
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.expenses.size).isEqualTo(initialExpenses.size + 1)
+            val addedExpense = emission.expenses.find { it.description == newDesc }
+            assertThat(addedExpense).isNotNull()
+            assertThat(addedExpense?.category).isEqualTo(newCat)
+            assertThat(addedExpense?.amount).isEqualTo(newAmount)
+
+            assertThat(emission.totalExpenses).isEqualTo(initialTotal + newAmount)
+            assertThat(emission.userMessage).isEqualTo("'$newDesc' added to expenses.")
+
+            // Verify sorting includes the new item correctly (most recent first)
+            if (emission.expenses.size > 1) {
+                for (i in 0 until emission.expenses.size - 1) {
+                    assertThat(emission.expenses[i].expenseDate).isAtLeast(emission.expenses[i+1].expenseDate)
+                }
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+
+    @Test
+    fun `onUserMessageShown clears userMessage`() = runTest {
+        viewModel.addExpensePlaceholder()
+        testDispatcher.scheduler.runCurrent()
+        assertThat(viewModel.uiState.value.userMessage).isNotNull()
+
+        viewModel.onUserMessageShown()
+        viewModel.uiState.test {
+            val emission = awaitItem()
+            assertThat(emission.userMessage).isNull()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
- Added ExpenseItemUi data class for representing expense entries.
- Implemented ExpensesViewModel with mock data, UiState (including total expenses calculation), and placeholder functions for adding and viewing expenses.
- Designed and implemented ExpensesScreen UI using Jetpack Compose, displaying a list of expenses, a summary header for total expenses, a FAB, and click handlers for items.
- Integrated Toast messages for user feedback via ViewModel state.
- Added unit tests for ExpensesViewModel.
- Added basic UI tests for ExpensesScreen.