### PR TITLE
feat: Implement consistent TopAppBars with back navigation

### DIFF
--- a/app/src/main/java/com/example/store/presentation/common/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/example/store/presentation/common/navigation/MainNavHost.kt
@@ -49,22 +49,22 @@ fun MainNavHost(navController: NavHostController) {
             DashboardScreen(navController = navController)
         }
         composable(ScreenRoutes.SALES) {
-            SalesScreen()
+            SalesScreen(navController = navController)
         }
         composable(ScreenRoutes.INVENTORY) { // Changed from PRODUCTS
-            InventoryScreen()
+            InventoryScreen(navController = navController)
         }
         composable(ScreenRoutes.PURCHASES) {
-            PurchasesScreen()
+            PurchasesScreen(navController = navController)
         }
         composable(ScreenRoutes.ORDERS) {
-            OrdersScreen()
+            OrdersScreen(navController = navController)
         }
         composable(ScreenRoutes.SCANNER) {
-            ScannerScreen()
+            ScannerScreen(navController = navController)
         }
         composable(ScreenRoutes.EXPENSES) {
-            ExpensesScreen()
+            ExpensesScreen(navController = navController)
         }
         // Removed composables for CATEGORIES, CUSTOMERS, REPORTS
     }

--- a/app/src/main/java/com/example/store/presentation/expenses/ui/ExpensesScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/expenses/ui/ExpensesScreen.kt
@@ -19,9 +19,22 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.store.presentation.expenses.ExpensesViewModel
 import com.example.store.presentation.expenses.model.ExpenseItemUi
 
+import androidx.navigation.NavController
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ExpensesScreen(
+    navController: NavController, // Added NavController
+    viewModel: ExpensesViewModel = viewModel()
+) {
+import androidx.compose.material.icons.Icons // Keep or remove as needed
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.navigation.NavController // Ensure this import is present
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ExpensesScreen(
+    navController: NavController,
     viewModel: ExpensesViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -38,6 +51,14 @@ fun ExpensesScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Manage Expenses") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer

--- a/app/src/main/java/com/example/store/presentation/inventory/ui/InventoryScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/inventory/ui/InventoryScreen.kt
@@ -20,9 +20,22 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.store.presentation.inventory.InventoryViewModel
 import com.example.store.presentation.inventory.model.InventoryItemUi
 
+import androidx.navigation.NavController
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InventoryScreen(
+    navController: NavController, // Added NavController
+    viewModel: InventoryViewModel = viewModel()
+) {
+import androidx.compose.material.icons.Icons // Keep this if other icons are used, or remove if only ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.navigation.NavController
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InventoryScreen(
+    navController: NavController,
     viewModel: InventoryViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -31,7 +44,7 @@ fun InventoryScreen(
     LaunchedEffect(key1 = uiState.userMessage) {
         uiState.userMessage?.let {
             Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
-            viewModel.onUserMessageShown() // Important to consume the message
+            viewModel.onUserMessageShown()
         }
     }
 
@@ -39,6 +52,14 @@ fun InventoryScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Inventory Management") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer

--- a/app/src/main/java/com/example/store/presentation/orders/ui/OrdersScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/orders/ui/OrdersScreen.kt
@@ -24,9 +24,22 @@ import com.example.store.presentation.orders.OrdersViewModel
 import com.example.store.presentation.orders.model.OrderItemUi
 import com.example.store.presentation.orders.model.OrderStatus
 
+import androidx.navigation.NavController
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OrdersScreen(
+    navController: NavController, // Added NavController
+    viewModel: OrdersViewModel = viewModel()
+) {
+import androidx.compose.material.icons.Icons // Keep or remove as needed
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.navigation.NavController // Ensure this import is present
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OrdersScreen(
+    navController: NavController,
     viewModel: OrdersViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -43,6 +56,14 @@ fun OrdersScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Customer Orders") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer

--- a/app/src/main/java/com/example/store/presentation/purchases/ui/PurchasesScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/purchases/ui/PurchasesScreen.kt
@@ -18,9 +18,22 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.store.presentation.purchases.PurchasesViewModel
 import com.example.store.presentation.purchases.model.PurchaseItemUi
 
+import androidx.navigation.NavController
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PurchasesScreen(
+    navController: NavController, // Added NavController
+    viewModel: PurchasesViewModel = viewModel()
+) {
+import androidx.compose.material.icons.Icons // Keep or remove based on other icon usage
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.navigation.NavController // Ensure this import is present
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PurchasesScreen(
+    navController: NavController,
     viewModel: PurchasesViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -37,6 +50,14 @@ fun PurchasesScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Purchase History") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer

--- a/app/src/main/java/com/example/store/presentation/sales/ui/SalesScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/sales/ui/SalesScreen.kt
@@ -18,9 +18,22 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.store.presentation.sales.SalesViewModel
 import com.example.store.presentation.sales.model.SaleItemUi
 
+import androidx.navigation.NavController
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SalesScreen(
+    navController: NavController, // Added NavController
+    viewModel: SalesViewModel = viewModel()
+) {
+import androidx.compose.material.icons.Icons // Keep or remove based on other icon usage
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.navigation.NavController // Ensure this import is present
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SalesScreen(
+    navController: NavController,
     viewModel: SalesViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -37,6 +50,14 @@ fun SalesScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Sales Transactions") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer

--- a/app/src/main/java/com/example/store/presentation/scanner/ui/ScannerScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/scanner/ui/ScannerScreen.kt
@@ -23,9 +23,22 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.store.presentation.scanner.ScannerViewModel
 import com.example.store.presentation.scanner.model.ScannedDataUi
 
+import androidx.navigation.NavController
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ScannerScreen(
+    navController: NavController, // Added NavController
+    viewModel: ScannerViewModel = viewModel()
+) {
+import androidx.compose.material.icons.Icons // Keep or remove as needed
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.navigation.NavController // Ensure this import is present
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ScannerScreen(
+    navController: NavController,
     viewModel: ScannerViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -42,6 +55,14 @@ fun ScannerScreen(
         topBar = {
             TopAppBar(
                 title = { Text("Barcode Scanner") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
                 colors = TopAppBarDefaults.topAppBarColors(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer


### PR DESCRIPTION
- Added a back navigation arrow (IconButton with ArrowBack icon) to the TopAppBar of the following screens: Inventory, Purchases, Sales, Orders, Scanner, and Expenses.
- Ensured each of these screens receives a NavController instance.
- The back arrow's onClick action calls navController.popBackStack() to navigate to the previous screen (typically the Dashboard).
- Verified that the Dashboard screen's TopAppBar does not have a back arrow, as intended.