### PR TITLE
fix: Resolve specific compilation errors

### DIFF
--- a/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
@@ -233,7 +233,7 @@ fun DashboardScreen(
                                 Divider()
                             }
                             // Actions for all notifications
-                            if (uiState.notifications.any { !it.isRead }) {
+                            if (uiState.notifications.any { notificationItem -> !notificationItem.isRead }) { // Explicit lambda parameter
                                 DropdownMenuItem(
                                     text = { Row(verticalAlignment = Alignment.CenterVertically) {
                                         Icon(Icons.Filled.DoneAll, contentDescription = "Mark all read", modifier = Modifier.size(18.dp))

--- a/app/src/main/java/com/example/store/presentation/scanner/ui/ScannerScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/scanner/ui/ScannerScreen.kt
@@ -2,6 +2,7 @@ package com.example.store.presentation.scanner.ui
 
 import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border // Explicit import for Modifier.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items


### PR DESCRIPTION
- Added explicit import for `androidx.compose.foundation.border` in `ScannerScreen.kt` to fix an unresolved reference error for the `border` modifier.
- Refactored a lambda expression in `DashboardScreen.kt` within the notification panel logic (`notifications.any`) to use an explicit parameter name, aiming to resolve potential 'unresolved reference' errors reported by the compiler/IDE.