### PR TITLE
Fix: Add explicit keys to LazyColumns in dashboard card dropdowns

### DIFF
--- a/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
@@ -578,7 +578,7 @@ private fun DashboardCard(
                                     )
                                 } else {
                                     LazyColumn(modifier = Modifier.heightIn(max = 120.dp)) {
-                                        items(uiState.lowStockItemsList) { item ->
+                                        items(uiState.lowStockItemsList, key = { it.id }) { item -> // Added key here
                                             DropdownMenuItem(
                                                 text = { Text(item.message) },
                                                 onClick = {
@@ -636,10 +636,10 @@ private fun DashboardCard(
                                         onClick = { showExpiringDropdown = false }
                                     )
                                 } else {
-                                    LazyColumn(modifier = Modifier.heightIn(max = 120.dp)) {
-                                        items(uiState.expiringItemsList) { item ->
+                                        LazyColumn(modifier = Modifier.heightIn(max = 120.dp)) {
+                                            items(uiState.expiringItemsList, key = { it.id }) { item -> // Added key here
                                             DropdownMenuItem(
-                                                text = { Text(item.message) },
+                                                    text = { Text(item.message) },
                                                 onClick = {
                                                     Toast.makeText(context, item.message, Toast.LENGTH_SHORT).show()
                                                     showExpiringDropdown = false


### PR DESCRIPTION
- Applied explicit unique item keys (`key = { it.id }`) to the LazyColumns used within the 'Low Availability' and 'Expiring Soon' section dropdowns on the dashboard.
- This is intended to fix crashes that were occurring when these dropdowns were opened, by improving the stability and item tracking of the LazyColumns.