### PR TITLE
Diag: Extremely simplify dropdowns for crash diagnosis

### DIFF
--- a/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
@@ -571,24 +571,13 @@ private fun DashboardCard(
                                 onDismissRequest = { showLowStockDropdown = false },
                                 modifier = Modifier.widthIn(min = 180.dp, max = 240.dp)
                             ) {
-                                if (uiState.lowStockItemsList.isEmpty()) {
-                                    DropdownMenuItem(
-                                        text = { Text("No low availability items.") },
-                                        onClick = { showLowStockDropdown = false }
-                                    )
-                                } else {
-                                    LazyColumn(modifier = Modifier.heightIn(max = 120.dp)) {
-                                        items(uiState.lowStockItemsList, key = { it.id }) { item -> // Added key here
-                                            DropdownMenuItem(
-                                                text = { Text(item.message) },
-                                                onClick = {
-                                                    Toast.makeText(context, item.message, Toast.LENGTH_SHORT).show()
-                                                    showLowStockDropdown = false
-                                                }
-                                            )
-                                        }
+                                DropdownMenuItem(
+                                    text = { Text("Static Low Availability Item") },
+                                    onClick = {
+                                        Toast.makeText(context, "Static Low Availability clicked", Toast.LENGTH_SHORT).show()
+                                        showLowStockDropdown = false
                                     }
-                                }
+                                )
                             }
                         }
                         Spacer(modifier = Modifier.height(4.dp))
@@ -630,24 +619,13 @@ private fun DashboardCard(
                                 onDismissRequest = { showExpiringDropdown = false },
                                 modifier = Modifier.widthIn(min = 180.dp, max = 240.dp)
                             ) {
-                                if (uiState.expiringItemsList.isEmpty()) {
-                                    DropdownMenuItem(
-                                        text = { Text("No expiring items.") },
-                                        onClick = { showExpiringDropdown = false }
-                                    )
-                                } else {
-                                        LazyColumn(modifier = Modifier.heightIn(max = 120.dp)) {
-                                            items(uiState.expiringItemsList, key = { it.id }) { item -> // Added key here
-                                            DropdownMenuItem(
-                                                    text = { Text(item.message) },
-                                                onClick = {
-                                                    Toast.makeText(context, item.message, Toast.LENGTH_SHORT).show()
-                                                    showExpiringDropdown = false
-                                                }
-                                            )
-                                        }
+                                DropdownMenuItem(
+                                    text = { Text("Static Expiring Soon Item") },
+                                    onClick = {
+                                        Toast.makeText(context, "Static Expiring Soon clicked", Toast.LENGTH_SHORT).show()
+                                        showExpiringDropdown = false
                                     }
-                                }
+                                )
                             }
                         }
                         Spacer(modifier = Modifier.height(4.dp))


### PR DESCRIPTION
- Reduced content of 'Low Availability' and 'Expiring Soon' dropdown menus to a single static DropdownMenuItem each.
- Removed LazyColumn and all conditional logic from these dropdowns.
- This change is for diagnostic purposes to determine if the crash upon opening these dropdowns is related to their complex content (LazyColumn, dynamic data) or a more fundamental issue with DropdownMenu in this context.