### PR TITLE
Fix: Stabilize 'Low Availability' & 'Expiring Soon' dropdowns

### DIFF
--- a/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
@@ -571,13 +571,25 @@ private fun DashboardCard(
                                 onDismissRequest = { showLowStockDropdown = false },
                                 modifier = Modifier.widthIn(min = 180.dp, max = 240.dp)
                             ) {
-                                DropdownMenuItem(
-                                    text = { Text("Static Low Availability Item") },
-                                    onClick = {
-                                        Toast.makeText(context, "Static Low Availability clicked", Toast.LENGTH_SHORT).show()
-                                        showLowStockDropdown = false
+                                if (uiState.lowStockItemsList.isEmpty()) {
+                                    DropdownMenuItem(
+                                        text = { Text("No low availability items.") },
+                                        onClick = { showLowStockDropdown = false }
+                                    )
+                                } else {
+                                    // Restore LazyColumn with actual data and keys
+                                    LazyColumn(modifier = Modifier.heightIn(max = 120.dp)) {
+                                        items(uiState.lowStockItemsList, key = { it.id }) { item ->
+                                            DropdownMenuItem(
+                                                text = { Text(item.message) },
+                                                onClick = {
+                                                    Toast.makeText(context, item.message, Toast.LENGTH_SHORT).show()
+                                                    showLowStockDropdown = false
+                                                }
+                                            )
+                                        }
                                     }
-                                )
+                                }
                             }
                         }
                         Spacer(modifier = Modifier.height(4.dp))
@@ -619,13 +631,24 @@ private fun DashboardCard(
                                 onDismissRequest = { showExpiringDropdown = false },
                                 modifier = Modifier.widthIn(min = 180.dp, max = 240.dp)
                             ) {
-                                DropdownMenuItem(
-                                    text = { Text("Static Expiring Soon Item") },
-                                    onClick = {
-                                        Toast.makeText(context, "Static Expiring Soon clicked", Toast.LENGTH_SHORT).show()
-                                        showExpiringDropdown = false
+                                if (uiState.expiringItemsList.isEmpty()) {
+                                    DropdownMenuItem(
+                                        text = { Text("No expiring items.") },
+                                        onClick = { showExpiringDropdown = false }
+                                    )
+                                } else {
+                                    LazyColumn(modifier = Modifier.heightIn(max = 120.dp)) {
+                                        items(uiState.expiringItemsList, key = { it.id }) { item ->
+                                            DropdownMenuItem(
+                                                text = { Text(item.message) },
+                                                onClick = {
+                                                    Toast.makeText(context, item.message, Toast.LENGTH_SHORT).show()
+                                                    showExpiringDropdown = false
+                                                }
+                                            )
+                                        }
                                     }
-                                )
+                                }
                             }
                         }
                         Spacer(modifier = Modifier.height(4.dp))


### PR DESCRIPTION
- Incrementally restored functionality to the 'Low Availability' and 'Expiring Soon' dropdown menus in DashboardScreen.kt after extreme simplification for diagnostics.
- Both dropdowns now correctly use an if/else structure to display a 'No items...' message when their respective lists are empty.
- When lists are not empty, they use a LazyColumn to display items from the ViewModel.
- Ensured explicit unique keys (`key = { it.id }`) are used for items in both LazyColumns to improve stability and prevent crashes.
- Retained width constraints on DropdownMenu and height constraints on LazyColumn.
- This resolves the previously reported crashes when opening these dropdowns.