### PR TITLE
Diag: Render empty DropdownMenus for graphics crash diagnosis

### DIFF
--- a/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
@@ -571,26 +571,7 @@ private fun DashboardCard(
                                 onDismissRequest = { showLowStockDropdown = false },
                                 modifier = Modifier.width(220.dp) // Applied fixed width to DropdownMenu
                             ) {
-                                if (uiState.lowStockItemsList.isEmpty()) {
-                                    DropdownMenuItem(
-                                        text = { Text("No low availability items.") },
-                                        onClick = { showLowStockDropdown = false }
-                                    )
-                                } else {
-                                    Box(modifier = Modifier.height(120.dp)) { // Fixed height Box for LazyColumn
-                                        LazyColumn { // LazyColumn fills the Box
-                                            items(uiState.lowStockItemsList, key = { it.id }) { item ->
-                                                DropdownMenuItem(
-                                                    text = { Text(item.message) },
-                                                    onClick = {
-                                                        Toast.makeText(context, item.message, Toast.LENGTH_SHORT).show()
-                                                        showLowStockDropdown = false
-                                                    }
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
+                                // No content here for diagnosis
                             }
                         }
                         Spacer(modifier = Modifier.height(4.dp))
@@ -632,26 +613,7 @@ private fun DashboardCard(
                                 onDismissRequest = { showExpiringDropdown = false },
                                 modifier = Modifier.width(220.dp) // Applied fixed width to DropdownMenu
                             ) {
-                                if (uiState.expiringItemsList.isEmpty()) {
-                                    DropdownMenuItem(
-                                        text = { Text("No expiring items.") },
-                                        onClick = { showExpiringDropdown = false }
-                                    )
-                                } else {
-                                    Box(modifier = Modifier.height(120.dp)) { // Fixed height Box for LazyColumn
-                                        LazyColumn { // LazyColumn fills the Box
-                                            items(uiState.expiringItemsList, key = { it.id }) { item ->
-                                                DropdownMenuItem(
-                                                    text = { Text(item.message) },
-                                                    onClick = {
-                                                        Toast.makeText(context, item.message, Toast.LENGTH_SHORT).show()
-                                                        showExpiringDropdown = false
-                                                    }
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
+                                // No content here for diagnosis
                             }
                         }
                         Spacer(modifier = Modifier.height(4.dp))


### PR DESCRIPTION
- Modified 'Low Availability' and 'Expiring Soon' DropdownMenus to render with no content at all.
- This is a diagnostic step to determine if the 'Channel is unrecoverably broken' crash (related to Modifier.graphicsLayer) occurs even when the DropdownMenu has no content to measure or compose, pointing to an issue with the basic popup window or graphics surface creation.