### PR TITLE
Fix: Restore LazyColumn in Dashboard Card Dropdowns with Sizing

### DIFF
--- a/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
@@ -571,7 +571,26 @@ private fun DashboardCard(
                                 onDismissRequest = { showLowStockDropdown = false },
                                 modifier = Modifier.width(220.dp) // Applied fixed width to DropdownMenu
                             ) {
-                                // No content here for diagnosis
+                                if (uiState.lowStockItemsList.isEmpty()) {
+                                    DropdownMenuItem(
+                                        text = { Text("No low availability items.") },
+                                        onClick = { showLowStockDropdown = false }
+                                    )
+                                } else {
+                                    Box(modifier = Modifier.height(120.dp)) {
+                                        LazyColumn { // Removed Modifier.fillMaxHeight() as Box defines height
+                                            items(uiState.lowStockItemsList, key = { it.id }) { item ->
+                                                DropdownMenuItem(
+                                                    text = { Text(item.message) },
+                                                    onClick = {
+                                                        Toast.makeText(context, item.message, Toast.LENGTH_SHORT).show()
+                                                        showLowStockDropdown = false
+                                                    }
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                         Spacer(modifier = Modifier.height(4.dp))
@@ -613,7 +632,26 @@ private fun DashboardCard(
                                 onDismissRequest = { showExpiringDropdown = false },
                                 modifier = Modifier.width(220.dp) // Applied fixed width to DropdownMenu
                             ) {
-                                // No content here for diagnosis
+                                if (uiState.expiringItemsList.isEmpty()) {
+                                    DropdownMenuItem(
+                                        text = { Text("No expiring items.") },
+                                        onClick = { showExpiringDropdown = false }
+                                    )
+                                } else {
+                                    Box(modifier = Modifier.height(120.dp)) {
+                                        LazyColumn {
+                                            items(uiState.expiringItemsList, key = { it.id }) { item ->
+                                                DropdownMenuItem(
+                                                    text = { Text(item.message) },
+                                                    onClick = {
+                                                        Toast.makeText(context, item.message, Toast.LENGTH_SHORT).show()
+                                                        showExpiringDropdown = false
+                                                    }
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                         Spacer(modifier = Modifier.height(4.dp))


### PR DESCRIPTION
- Re-enabled LazyColumn for item display within the 'Low Availability' and 'Expiring Soon' dropdown menus on the dashboard.
- This follows diagnostic steps that confirmed an empty DropdownMenu could be shown, indicating the 'Channel is unrecoverably broken' error was related to content rendering.
- The fix involves:
  - Setting a fixed width (`Modifier.width(220.dp)`) on the `DropdownMenu` components.
  - Wrapping the `LazyColumn` inside a `Box` with a fixed height (`Modifier.height(120.dp)`).
  - Ensuring `LazyColumn` uses unique item keys (`key = { it.id }`).
- These changes address both the `IllegalStateException` (intrinsic measurements) and the subsequent `graphicsLayer` / channel broken errors by providing explicit sizes and stable item identities, allowing the dropdowns to function correctly with dynamic content.