### PR TITLE
Fix: Resolve intrinsic measurement crash in dashboard dropdowns

### DIFF
--- a/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
@@ -578,7 +578,7 @@ private fun DashboardCard(
                                     )
                                 } else {
                                     Box(modifier = Modifier.height(120.dp)) {
-                                        LazyColumn { // Removed Modifier.fillMaxHeight() as Box defines height
+                                        LazyColumn(modifier = Modifier.fillMaxWidth()) { // Added fillMaxWidth
                                             items(uiState.lowStockItemsList, key = { it.id }) { item ->
                                                 DropdownMenuItem(
                                                     text = { Text(item.message) },
@@ -639,7 +639,7 @@ private fun DashboardCard(
                                     )
                                 } else {
                                     Box(modifier = Modifier.height(120.dp)) {
-                                        LazyColumn {
+                                        LazyColumn(modifier = Modifier.fillMaxWidth()) { // Added fillMaxWidth
                                             items(uiState.expiringItemsList, key = { it.id }) { item ->
                                                 DropdownMenuItem(
                                                     text = { Text(item.message) },


### PR DESCRIPTION
- Addressed `IllegalStateException: Asking for intrinsic measurements of SubcomposeLayout layouts is not supported` when using LazyColumn inside DropdownMenu.
- Applied `Modifier.fillMaxWidth()` to the LazyColumn components within the 'Low Availability' and 'Expiring Soon' dropdowns.
- This complements previous fixes (fixed width on DropdownMenu, fixed height Box around LazyColumn, and item keys) by ensuring the LazyColumn has explicit width constraints from its parent.
- This set of changes provides comprehensive size information to the DropdownMenu's SubcomposeLayout, preventing the unsupported intrinsic measurement queries and resolving the crash.