### PR TITLE
Fix: Explicitly instantiate ViewModel in DashboardPreview

### DIFF
--- a/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
+++ b/app/src/main/java/com/example/store/presentation/dashboard/ui/DashboardScreen.kt
@@ -920,6 +920,10 @@ private fun ChartsSectionPlaceholder(modifier: Modifier = Modifier) {
 fun DashboardPreview() {
     MaterialTheme {
         // Provide a dummy NavController for the preview
-        DashboardScreen(navController = rememberNavController())
+        // Explicitly create a DashboardViewModel for the preview
+        DashboardScreen(
+            navController = rememberNavController(),
+            viewModel = DashboardViewModel() // Explicitly pass a new instance
+        )
     }
 }


### PR DESCRIPTION
- Updated `DashboardPreview` in `DashboardScreen.kt` to explicitly pass a new instance of `DashboardViewModel()`.
- This avoids potential issues with the default `viewModel()` delegate in Jetpack Compose previews related to `ViewModelStoreOwner` or coroutine scopes, making the preview more likely to render correctly and stably.