### PR TITLE
Feat(Room): Implement Phase 2 - Order Management Entities

### DIFF
--- a/DATABASE_IMPLEMENTATION_PROGRESS.md
+++ b/DATABASE_IMPLEMENTATION_PROGRESS.md
@@ -4,7 +4,7 @@ This document tracks the progress of implementing the local Room database and fu
 
 ## Overall Plan
 
-*   **Phase 1: Core Entities Setup (Product, Customer, Supplier) with Room**
+*   [X] **Phase 1: Core Entities Setup (Product, Customer, Supplier) with Room** - *COMPLETED*
     *   [X] Stage 1.1: Add Room Dependencies & Initial Progress File
     *   [X] Stage 1.2: Define `ProductEntity` & `ProductDao` - *Completed*
     *   [X] Stage 1.3: Define `CustomerEntity` & `CustomerDao` - *Completed*
@@ -12,12 +12,12 @@ This document tracks the progress of implementing the local Room database and fu
     *   [X] Stage 1.5: Create `AppDatabase` class - *Completed*
     *   [X] Stage 1.6: Implement basic Repository for Product, Customer, Supplier. - *Completed*
     *   [X] Stage 1.7: Initial integration for creating/reading entities. - *Completed*
-*   **Phase 2: Order Management Entities (Room)**
-    *   [ ] Stage 2.1: Define `OrderEntity` & `OrderDao`
-    *   [ ] Stage 2.2: Define `OrderItemEntity` & `OrderItemDao`
-    *   [ ] Stage 2.3: Update `AppDatabase`
-    *   [ ] Stage 2.4: Extend Repository for Orders.
-    *   [ ] Stage 2.5: Integrate Order creation/viewing.
+*   [X] **Phase 2: Order Management Entities (Room)** - *COMPLETED*
+    *   [X] Stage 2.1: Define `OrderEntity` & `OrderDao` - *Completed*
+    *   [X] Stage 2.2: Define `OrderItemEntity` & `OrderItemDao` - *Completed*
+    *   [X] Stage 2.3: Update `AppDatabase` - *Completed*
+    *   [X] Stage 2.4: Extend Repository for Orders. - *Completed*
+    *   [X] Stage 2.5: Integrate Order creation/viewing. - *Completed*
 *   **Phase 3: User Preferences (Room)**
     *   [ ] Stage 3.1: Define `UserPreferenceEntity` & `UserPreferenceDao`
     *   [ ] Stage 3.2: Update `AppDatabase`

--- a/app/src/main/java/com/example/store/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/example/store/data/local/AppDatabase.kt
@@ -7,17 +7,23 @@ import androidx.room.RoomDatabase
 import com.example.store.data.local.dao.CustomerDao
 import com.example.store.data.local.dao.ProductDao
 import com.example.store.data.local.dao.SupplierDao
+import com.example.store.data.local.dao.OrderDao // New import
+import com.example.store.data.local.dao.OrderItemDao // New import
 import com.example.store.data.local.entity.CustomerEntity
 import com.example.store.data.local.entity.ProductEntity
 import com.example.store.data.local.entity.SupplierEntity
+import com.example.store.data.local.entity.OrderEntity // New import
+import com.example.store.data.local.entity.OrderItemEntity // New import
 
 @Database(
     entities = [
         ProductEntity::class,
         CustomerEntity::class,
-        SupplierEntity::class
+        SupplierEntity::class,
+        OrderEntity::class,      // Added OrderEntity
+        OrderItemEntity::class   // Added OrderItemEntity
     ],
-    version = 1,
+    version = 2, // Incremented version
     exportSchema = false // For now, we'll keep schema export off. Can be enabled for complex migrations.
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -25,6 +31,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun productDao(): ProductDao
     abstract fun customerDao(): CustomerDao
     abstract fun supplierDao(): SupplierDao
+    abstract fun orderDao(): OrderDao           // Added OrderDao accessor
+    abstract fun orderItemDao(): OrderItemDao   // Added OrderItemDao accessor
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/example/store/data/local/dao/OrderDao.kt
+++ b/app/src/main/java/com/example/store/data/local/dao/OrderDao.kt
@@ -1,0 +1,38 @@
+package com.example.store.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import com.example.store.data.local.entity.OrderEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface OrderDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertOrder(order: OrderEntity)
+
+    @Update
+    suspend fun updateOrder(order: OrderEntity)
+
+    @Delete
+    suspend fun deleteOrder(order: OrderEntity)
+
+    @Query("SELECT * FROM orders WHERE orderId = :orderId")
+    fun getOrderById(orderId: String): Flow<OrderEntity?>
+
+    @Query("SELECT * FROM orders ORDER BY orderDate DESC")
+    fun getAllOrders(): Flow<List<OrderEntity>>
+
+    @Query("SELECT * FROM orders WHERE customerId = :customerId ORDER BY orderDate DESC")
+    fun getOrdersByCustomerId(customerId: String): Flow<List<OrderEntity>>
+
+    @Query("SELECT * FROM orders WHERE status = :status ORDER BY orderDate DESC")
+    fun getOrdersByStatus(status: String): Flow<List<OrderEntity>>
+
+    @Query("DELETE FROM orders")
+    suspend fun deleteAllOrders()
+}

--- a/app/src/main/java/com/example/store/data/local/dao/OrderItemDao.kt
+++ b/app/src/main/java/com/example/store/data/local/dao/OrderItemDao.kt
@@ -1,0 +1,57 @@
+package com.example.store.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Embedded
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Relation
+import androidx.room.Transaction
+import androidx.room.Update
+import com.example.store.data.local.entity.OrderEntity
+import com.example.store.data.local.entity.OrderItemEntity
+import kotlinx.coroutines.flow.Flow
+
+// POKO for representing an Order with its associated OrderItems
+data class OrderWithOrderItems(
+    @Embedded val order: OrderEntity,
+    @Relation(
+        parentColumn = "orderId",
+        entityColumn = "orderId"
+    )
+    val items: List<OrderItemEntity>
+)
+
+@Dao
+interface OrderItemDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertOrderItem(orderItem: OrderItemEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAllOrderItems(orderItems: List<OrderItemEntity>)
+
+    @Update
+    suspend fun updateOrderItem(orderItem: OrderItemEntity)
+
+    @Delete
+    suspend fun deleteOrderItem(orderItem: OrderItemEntity)
+
+    @Query("SELECT * FROM order_items WHERE orderId = :orderId")
+    fun getOrderItemsForOrder(orderId: String): Flow<List<OrderItemEntity>>
+
+    @Transaction // Ensures the read operation is atomic
+    @Query("SELECT * FROM orders WHERE orderId = :orderId")
+    fun getOrderWithOrderItems(orderId: String): Flow<OrderWithOrderItems?>
+
+    @Transaction
+    @Query("SELECT * FROM orders")
+    fun getAllOrdersWithOrderItems(): Flow<List<OrderWithOrderItems>>
+
+    @Query("DELETE FROM order_items WHERE orderId = :orderId")
+    suspend fun deleteAllOrderItemsForOrder(orderId: String)
+
+    @Query("DELETE FROM order_items")
+    suspend fun deleteAllOrderItems()
+}

--- a/app/src/main/java/com/example/store/data/local/entity/OrderEntity.kt
+++ b/app/src/main/java/com/example/store/data/local/entity/OrderEntity.kt
@@ -1,0 +1,27 @@
+package com.example.store.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+@Entity(
+    tableName = "orders",
+    foreignKeys = [
+        ForeignKey(
+            entity = CustomerEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["customerId"],
+            onDelete = ForeignKey.SET_NULL // If customer is deleted, set customerId to null in order
+        )
+    ],
+    indices = [Index(value = ["customerId"])]
+)
+data class OrderEntity(
+    @PrimaryKey val orderId: String = UUID.randomUUID().toString(),
+    val customerId: String?, // Nullable if customer can be anonymous or deleted
+    val orderDate: Long = System.currentTimeMillis(),
+    val status: String, // e.g., "Pending", "Processing", "Shipped", "Delivered", "Canceled"
+    val totalAmount: Double
+)

--- a/app/src/main/java/com/example/store/data/local/entity/OrderItemEntity.kt
+++ b/app/src/main/java/com/example/store/data/local/entity/OrderItemEntity.kt
@@ -1,0 +1,34 @@
+package com.example.store.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import java.util.UUID
+
+@Entity(
+    tableName = "order_items",
+    primaryKeys = ["orderItemId"], // Explicitly defined composite PK if needed, or single as here.
+    foreignKeys = [
+        ForeignKey(
+            entity = OrderEntity::class,
+            parentColumns = ["orderId"],
+            childColumns = ["orderId"],
+            onDelete = ForeignKey.CASCADE // If an order is deleted, its items are also deleted.
+        ),
+        ForeignKey(
+            entity = ProductEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["productId"],
+            onDelete = ForeignKey.SET_NULL // If a product is deleted, keep the order item but nullify productId
+                                         // Alternatively, could be RESTRICT or NO_ACTION depending on business rules.
+        )
+    ],
+    indices = [Index(value = ["orderId"]), Index(value = ["productId"])]
+)
+data class OrderItemEntity(
+    val orderItemId: String = UUID.randomUUID().toString(),
+    val orderId: String,
+    val productId: String?, // Nullable if product is deleted (due to SET_NULL)
+    val quantity: Int,
+    val pricePerUnit: Double // Price of the product at the time the order was placed
+)

--- a/app/src/main/java/com/example/store/data/repository/AppRepository.kt
+++ b/app/src/main/java/com/example/store/data/repository/AppRepository.kt
@@ -1,8 +1,11 @@
 package com.example.store.data.repository
 
+import com.example.store.data.local.dao.OrderWithOrderItems // New import
 import com.example.store.data.local.entity.CustomerEntity
 import com.example.store.data.local.entity.ProductEntity
 import com.example.store.data.local.entity.SupplierEntity
+import com.example.store.data.local.entity.OrderEntity // New import
+import com.example.store.data.local.entity.OrderItemEntity // New import
 import kotlinx.coroutines.flow.Flow
 
 interface AppRepository {
@@ -32,4 +35,25 @@ interface AppRepository {
     suspend fun updateSupplier(supplier: SupplierEntity)
     suspend fun deleteSupplier(supplier: SupplierEntity)
     suspend fun deleteAllSuppliers()
+
+    // Order Methods
+    fun getAllOrders(): Flow<List<OrderEntity>>
+    fun getOrderById(orderId: String): Flow<OrderEntity?>
+    fun getOrdersByCustomerId(customerId: String): Flow<List<OrderEntity>>
+    suspend fun insertOrder(order: OrderEntity)
+    suspend fun updateOrder(order: OrderEntity)
+    suspend fun deleteOrder(order: OrderEntity)
+
+    // OrderItem Methods
+    fun getOrderItemsForOrder(orderId: String): Flow<List<OrderItemEntity>>
+    suspend fun insertOrderItem(orderItem: OrderItemEntity)
+    suspend fun insertAllOrderItems(orderItems: List<OrderItemEntity>)
+    suspend fun updateOrderItem(orderItem: OrderItemEntity)
+    suspend fun deleteOrderItem(orderItem: OrderItemEntity)
+    suspend fun deleteAllOrderItemsForOrder(orderId: String)
+
+    // Combined Operations
+    fun getOrderWithOrderItems(orderId: String): Flow<OrderWithOrderItems?>
+    fun getAllOrdersWithOrderItems(): Flow<List<OrderWithOrderItems>>
+    suspend fun insertOrderWithItems(order: OrderEntity, items: List<OrderItemEntity>)
 }

--- a/app/src/main/java/com/example/store/data/repository/AppRepositoryImpl.kt
+++ b/app/src/main/java/com/example/store/data/repository/AppRepositoryImpl.kt
@@ -3,16 +3,23 @@ package com.example.store.data.repository
 import com.example.store.data.local.dao.CustomerDao
 import com.example.store.data.local.dao.ProductDao
 import com.example.store.data.local.dao.SupplierDao
+import com.example.store.data.local.dao.OrderDao // New import
+import com.example.store.data.local.dao.OrderItemDao // New import
+import com.example.store.data.local.dao.OrderWithOrderItems // New import
 import com.example.store.data.local.entity.CustomerEntity
 import com.example.store.data.local.entity.ProductEntity
 import com.example.store.data.local.entity.SupplierEntity
+import com.example.store.data.local.entity.OrderEntity // New import
+import com.example.store.data.local.entity.OrderItemEntity // New import
 import kotlinx.coroutines.flow.Flow
 
 // In a real app, DAOs would likely be injected (e.g., using Hilt)
 class AppRepositoryImpl(
     private val productDao: ProductDao,
     private val customerDao: CustomerDao,
-    private val supplierDao: SupplierDao
+    private val supplierDao: SupplierDao,
+    private val orderDao: OrderDao,         // New DAO
+    private val orderItemDao: OrderItemDao  // New DAO
 ) : AppRepository {
 
     // Product Methods
@@ -40,4 +47,33 @@ class AppRepositoryImpl(
     override suspend fun updateSupplier(supplier: SupplierEntity) = supplierDao.update(supplier)
     override suspend fun deleteSupplier(supplier: SupplierEntity) = supplierDao.delete(supplier)
     override suspend fun deleteAllSuppliers() = supplierDao.deleteAllSuppliers()
+
+    // Order Methods
+    override fun getAllOrders(): Flow<List<OrderEntity>> = orderDao.getAllOrders()
+    override fun getOrderById(orderId: String): Flow<OrderEntity?> = orderDao.getOrderById(orderId)
+    override fun getOrdersByCustomerId(customerId: String): Flow<List<OrderEntity>> = orderDao.getOrdersByCustomerId(customerId)
+    override suspend fun insertOrder(order: OrderEntity) = orderDao.insertOrder(order)
+    override suspend fun updateOrder(order: OrderEntity) = orderDao.updateOrder(order)
+    override suspend fun deleteOrder(order: OrderEntity) = orderDao.deleteOrder(order)
+
+    // OrderItem Methods
+    override fun getOrderItemsForOrder(orderId: String): Flow<List<OrderItemEntity>> = orderItemDao.getOrderItemsForOrder(orderId)
+    override suspend fun insertOrderItem(orderItem: OrderItemEntity) = orderItemDao.insertOrderItem(orderItem)
+    override suspend fun insertAllOrderItems(orderItems: List<OrderItemEntity>) = orderItemDao.insertAllOrderItems(orderItems)
+    override suspend fun updateOrderItem(orderItem: OrderItemEntity) = orderItemDao.updateOrderItem(orderItem)
+    override suspend fun deleteOrderItem(orderItem: OrderItemEntity) = orderItemDao.deleteOrderItem(orderItem)
+    override suspend fun deleteAllOrderItemsForOrder(orderId: String) = orderItemDao.deleteAllOrderItemsForOrder(orderId)
+
+    // Combined Operations
+    override fun getOrderWithOrderItems(orderId: String): Flow<OrderWithOrderItems?> = orderItemDao.getOrderWithOrderItems(orderId)
+    override fun getAllOrdersWithOrderItems(): Flow<List<OrderWithOrderItems>> = orderItemDao.getAllOrdersWithOrderItems()
+
+    override suspend fun insertOrderWithItems(order: OrderEntity, items: List<OrderItemEntity>) {
+        // This should ideally be a transaction handled at the DAO level if possible,
+        // or ensure DAOs handle conflicts appropriately.
+        // For simplicity here, we call them sequentially.
+        // A @Transaction method in a DAO would be better for atomicity.
+        orderDao.insertOrder(order)
+        orderItemDao.insertAllOrderItems(items.map { it.copy(orderId = order.orderId) }) // Ensure items have correct orderId
+    }
 }

--- a/app/src/main/java/com/example/store/di/DatabaseModule.kt
+++ b/app/src/main/java/com/example/store/di/DatabaseModule.kt
@@ -5,6 +5,8 @@ import com.example.store.data.local.AppDatabase
 import com.example.store.data.local.dao.CustomerDao
 import com.example.store.data.local.dao.ProductDao
 import com.example.store.data.local.dao.SupplierDao
+import com.example.store.data.local.dao.OrderDao // New
+import com.example.store.data.local.dao.OrderItemDao // New
 import com.example.store.data.repository.AppRepository
 import com.example.store.data.repository.AppRepositoryImpl
 import dagger.Module
@@ -44,11 +46,25 @@ object DatabaseModule {
 
     @Provides
     @Singleton
+    fun provideOrderDao(appDatabase: AppDatabase): OrderDao { // New provider
+        return appDatabase.orderDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideOrderItemDao(appDatabase: AppDatabase): OrderItemDao { // New provider
+        return appDatabase.orderItemDao()
+    }
+
+    @Provides
+    @Singleton
     fun provideAppRepository(
         productDao: ProductDao,
         customerDao: CustomerDao,
-        supplierDao: SupplierDao
+        supplierDao: SupplierDao,
+        orderDao: OrderDao,             // Added OrderDao
+        orderItemDao: OrderItemDao      // Added OrderItemDao
     ): AppRepository {
-        return AppRepositoryImpl(productDao, customerDao, supplierDao)
+        return AppRepositoryImpl(productDao, customerDao, supplierDao, orderDao, orderItemDao)
     }
 }

--- a/app/src/main/java/com/example/store/presentation/debug/DebugViewModel.kt
+++ b/app/src/main/java/com/example/store/presentation/debug/DebugViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.example.store.data.local.entity.CustomerEntity
 import com.example.store.data.local.entity.ProductEntity
 import com.example.store.data.local.entity.SupplierEntity
+import com.example.store.data.local.entity.OrderEntity // New
+import com.example.store.data.local.entity.OrderItemEntity // New
 import com.example.store.data.repository.AppRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,7 +25,8 @@ class DebugViewModel @Inject constructor(
 
     init {
         addMessage("DebugViewModel Initialized.")
-        testDatabaseOperations()
+        testCoreDatabaseOperations() // Renamed for clarity
+        testOrderOperations()      // New method call
     }
 
     private fun addMessage(message: String) {
@@ -31,9 +34,9 @@ class DebugViewModel @Inject constructor(
         // Log.d("DebugViewModel", message) // Optional: Log to Logcat
     }
 
-    fun testDatabaseOperations() {
+    fun testCoreDatabaseOperations() { // Renamed
         viewModelScope.launch {
-            addMessage("Starting database operations...")
+            addMessage("Starting core database operations (Products, Customers, Suppliers)...")
 
             // Clean up existing data for fresh test
             appRepository.deleteAllProducts()
@@ -72,6 +75,116 @@ class DebugViewModel @Inject constructor(
         viewModelScope.launch {
             appRepository.getAllSuppliers().collect { suppliers ->
                 addMessage("Fetched Suppliers (${suppliers.size}): ${suppliers.joinToString { it.name }}")
+            }
+        }
+    }
+
+    fun testOrderOperations() {
+        viewModelScope.launch {
+            addMessage("Starting order database operations...")
+
+            // --- Prerequisites: Ensure a customer and some products exist ---
+            // For simplicity, we'll try to fetch existing ones or insert new ones if needed.
+            // In a real test, you might want more deterministic setup.
+
+            var testCustomerId: String? = null
+            appRepository.getAllCustomers().collect { customers ->
+                if (customers.isNotEmpty()) {
+                    testCustomerId = customers.first().id
+                    addMessage("Using existing customer for order: ${customers.first().name}")
+                }
+            }
+            if (testCustomerId == null) {
+                val newCustomer = CustomerEntity(name = "Order Test Customer", email = "ordertest@example.com")
+                appRepository.insertCustomer(newCustomer)
+                testCustomerId = newCustomer.id
+                addMessage("Inserted new customer for order: ${newCustomer.name}")
+            }
+
+            val testProductIds = mutableListOf<String>()
+            val testProductPrices = mutableMapOf<String, Double>()
+
+            appRepository.getAllProducts().collect { products ->
+                if (products.size >= 2) {
+                    testProductIds.add(products[0].id)
+                    testProductPrices[products[0].id] = products[0].price
+                    testProductIds.add(products[1].id)
+                    testProductPrices[products[1].id] = products[1].price
+                    addMessage("Using existing products for order: ${products[0].name}, ${products[1].name}")
+                }
+            }
+
+            if (testProductIds.size < 2) {
+                val newProduct1 = ProductEntity(name = "OrderTest Product A", price = 10.0, stockQuantity = 10)
+                val newProduct2 = ProductEntity(name = "OrderTest Product B", price = 25.0, stockQuantity = 5)
+                appRepository.insertAllProducts(listOf(newProduct1, newProduct2))
+                testProductIds.clear() // Clear any partially filled list
+                testProductPrices.clear()
+                testProductIds.add(newProduct1.id)
+                testProductPrices[newProduct1.id] = newProduct1.price
+                testProductIds.add(newProduct2.id)
+                testProductPrices[newProduct2.id] = newProduct2.price
+                addMessage("Inserted new products for order: ${newProduct1.name}, ${newProduct2.name}")
+            }
+            // --- End Prerequisites ---
+
+            if (testCustomerId == null || testProductIds.size < 2) {
+                addMessage("Failed to setup prerequisites for order test. Aborting order operations.")
+                return@launch
+            }
+
+            // 1. Create and Insert an Order
+            val order1 = OrderEntity(
+                customerId = testCustomerId,
+                status = "Pending",
+                totalAmount = (1 * testProductPrices[testProductIds[0]]!!) + (2 * testProductPrices[testProductIds[1]]!!) // Calculated based on items below
+            )
+            // appRepository.insertOrder(order1) // Using insertOrderWithItems instead
+            // addMessage("Inserted Order ID: ${order1.orderId} for customer ID: $testCustomerId")
+
+            // 2. Create and Insert OrderItems
+            val orderItem1 = com.example.store.data.local.entity.OrderItemEntity(
+                orderId = order1.orderId, // Will be set by insertOrderWithItems if not set here
+                productId = testProductIds[0],
+                quantity = 1,
+                pricePerUnit = testProductPrices[testProductIds[0]]!!
+            )
+            val orderItem2 = com.example.store.data.local.entity.OrderItemEntity(
+                orderId = order1.orderId, // Will be set by insertOrderWithItems if not set here
+                productId = testProductIds[1],
+                quantity = 2,
+                pricePerUnit = testProductPrices[testProductIds[1]]!!
+            )
+            // appRepository.insertAllOrderItems(listOf(orderItem1, orderItem2))
+            // addMessage("Inserted 2 order items for Order ID: ${order1.orderId}")
+
+            // Use combined operation
+            appRepository.insertOrderWithItems(order1, listOf(orderItem1, orderItem2))
+            addMessage("Inserted Order ID: ${order1.orderId} with 2 items using combined operation.")
+
+
+            // 3. Fetch the Order with its Items and Log
+            appRepository.getOrderWithOrderItems(order1.orderId).collect { orderWithItems ->
+                if (orderWithItems != null) {
+                    addMessage("Fetched Order with Items: ID=${orderWithItems.order.orderId}, CustID=${orderWithItems.order.customerId}, Status=${orderWithItems.order.status}, Total=${orderWithItems.order.totalAmount}")
+                    orderWithItems.items.forEach { item ->
+                        addMessage("  Item: ProdID=${item.productId}, Qty=${item.quantity}, Price=${item.pricePerUnit}")
+                    }
+                } else {
+                    addMessage("Order with ID ${order1.orderId} not found after insert.")
+                }
+            }
+
+            // Fetch all orders with items to see the list
+            appRepository.getAllOrdersWithOrderItems().collect { allOrdersWithItems ->
+                 addMessage("--- All Orders with Items (${allOrdersWithItems.size}) ---")
+                 allOrdersWithItems.forEach { orderWithItems ->
+                     addMessage("Order: ID=${orderWithItems.order.orderId}, CustID=${orderWithItems.order.customerId}, Status=${orderWithItems.order.status}, Total=${orderWithItems.order.totalAmount}")
+                     orderWithItems.items.forEach { item ->
+                         addMessage("  Item: ProdID=${item.productId}, Qty=${item.quantity}, Price=${item.pricePerUnit}")
+                     }
+                 }
+                 addMessage("--- End of All Orders ---")
             }
         }
     }


### PR DESCRIPTION
Completed Phase 2 of Room database implementation for Order Management:

- Defined OrderEntity with foreign key to CustomerEntity.
- Defined OrderItemEntity with foreign keys to OrderEntity and ProductEntity.
- Created OrderDao and OrderItemDao with CRUD operations and specific queries, including OrderWithOrderItems POKO for combined results.
- Updated AppDatabase to include new entities/DAOs and incremented version to 2 (using fallbackToDestructiveMigration for now).
- Extended AppRepository and AppRepositoryImpl to handle order and order item operations.
- Updated Hilt's DatabaseModule to provide new DAOs to the repository.
- Added placeholder order operations to DebugViewModel for initial integration testing.
- Updated DATABASE_IMPLEMENTATION_PROGRESS.md to mark Phase 2 as complete.